### PR TITLE
feat(angular-rspack,angular-rsbuild): rename jit to aot

### DIFF
--- a/apps/docs/tsconfig.app.json
+++ b/apps/docs/tsconfig.app.json
@@ -29,9 +29,6 @@
       "path": "../../packages/angular-rspack-compiler/tsconfig.lib.json"
     },
     {
-      "path": "../../packages/compiler/tsconfig.lib.json"
-    },
-    {
       "path": "../../testing/setup/tsconfig.lib.json"
     },
     {

--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -19,9 +19,6 @@
       "path": "../../packages/angular-rspack-compiler"
     },
     {
-      "path": "../../packages/compiler"
-    },
-    {
       "path": "../../testing/setup"
     },
     {

--- a/e2e/fixtures/rsbuild-csr-css/tsconfig.app.json
+++ b/e2e/fixtures/rsbuild-csr-css/tsconfig.app.json
@@ -29,9 +29,6 @@
       "path": "../../../packages/angular-rspack-compiler/tsconfig.lib.json"
     },
     {
-      "path": "../../../packages/compiler/tsconfig.lib.json"
-    },
-    {
       "path": "../../../testing/setup/tsconfig.lib.json"
     },
     {

--- a/e2e/fixtures/rsbuild-csr-css/tsconfig.json
+++ b/e2e/fixtures/rsbuild-csr-css/tsconfig.json
@@ -19,9 +19,6 @@
       "path": "../../../packages/angular-rspack-compiler"
     },
     {
-      "path": "../../../packages/compiler"
-    },
-    {
       "path": "../../../testing/setup"
     },
     {

--- a/e2e/fixtures/rsbuild-csr-less/tsconfig.app.json
+++ b/e2e/fixtures/rsbuild-csr-less/tsconfig.app.json
@@ -29,9 +29,6 @@
       "path": "../../../packages/angular-rspack-compiler/tsconfig.lib.json"
     },
     {
-      "path": "../../../packages/compiler/tsconfig.lib.json"
-    },
-    {
       "path": "../../../testing/setup/tsconfig.lib.json"
     },
     {

--- a/e2e/fixtures/rsbuild-csr-less/tsconfig.json
+++ b/e2e/fixtures/rsbuild-csr-less/tsconfig.json
@@ -19,9 +19,6 @@
       "path": "../../../packages/angular-rspack-compiler"
     },
     {
-      "path": "../../../packages/compiler"
-    },
-    {
       "path": "../../../testing/setup"
     },
     {

--- a/e2e/fixtures/rsbuild-csr-scss/tsconfig.app.json
+++ b/e2e/fixtures/rsbuild-csr-scss/tsconfig.app.json
@@ -29,9 +29,6 @@
       "path": "../../../packages/angular-rspack-compiler/tsconfig.lib.json"
     },
     {
-      "path": "../../../packages/compiler/tsconfig.lib.json"
-    },
-    {
       "path": "../../../testing/setup/tsconfig.lib.json"
     },
     {

--- a/e2e/fixtures/rsbuild-csr-scss/tsconfig.json
+++ b/e2e/fixtures/rsbuild-csr-scss/tsconfig.json
@@ -19,9 +19,6 @@
       "path": "../../../packages/angular-rspack-compiler"
     },
     {
-      "path": "../../../packages/compiler"
-    },
-    {
       "path": "../../../testing/setup"
     },
     {

--- a/e2e/fixtures/rsbuild-ssr-css/tsconfig.app.json
+++ b/e2e/fixtures/rsbuild-ssr-css/tsconfig.app.json
@@ -29,9 +29,6 @@
       "path": "../../../packages/angular-rspack-compiler/tsconfig.lib.json"
     },
     {
-      "path": "../../../packages/compiler/tsconfig.lib.json"
-    },
-    {
       "path": "../../../testing/setup/tsconfig.lib.json"
     },
     {

--- a/e2e/fixtures/rsbuild-ssr-css/tsconfig.json
+++ b/e2e/fixtures/rsbuild-ssr-css/tsconfig.json
@@ -20,9 +20,6 @@
       "path": "../../../packages/angular-rspack-compiler"
     },
     {
-      "path": "../../../packages/compiler"
-    },
-    {
       "path": "../../../testing/setup"
     },
     {

--- a/e2e/fixtures/rspack-csr-css/tsconfig.app.json
+++ b/e2e/fixtures/rspack-csr-css/tsconfig.app.json
@@ -29,9 +29,6 @@
       "path": "../../../packages/angular-rspack-compiler/tsconfig.lib.json"
     },
     {
-      "path": "../../../packages/compiler/tsconfig.lib.json"
-    },
-    {
       "path": "../../../testing/setup/tsconfig.lib.json"
     },
     {

--- a/e2e/fixtures/rspack-csr-css/tsconfig.json
+++ b/e2e/fixtures/rspack-csr-css/tsconfig.json
@@ -19,9 +19,6 @@
       "path": "../../../packages/angular-rspack-compiler"
     },
     {
-      "path": "../../../packages/compiler"
-    },
-    {
       "path": "../../../testing/setup"
     },
     {

--- a/e2e/fixtures/rspack-ssr-css/tsconfig.app.json
+++ b/e2e/fixtures/rspack-ssr-css/tsconfig.app.json
@@ -29,9 +29,6 @@
       "path": "../../../packages/angular-rspack-compiler/tsconfig.lib.json"
     },
     {
-      "path": "../../../packages/compiler/tsconfig.lib.json"
-    },
-    {
       "path": "../../../testing/setup/tsconfig.lib.json"
     },
     {

--- a/e2e/fixtures/rspack-ssr-css/tsconfig.json
+++ b/e2e/fixtures/rspack-ssr-css/tsconfig.json
@@ -20,9 +20,6 @@
       "path": "../../../packages/angular-rspack-compiler"
     },
     {
-      "path": "../../../packages/compiler"
-    },
-    {
       "path": "../../../testing/setup"
     },
     {

--- a/e2e/rsbuild-csr-css-e2e/tsconfig.json
+++ b/e2e/rsbuild-csr-css-e2e/tsconfig.json
@@ -30,9 +30,6 @@
       "path": "../../packages/angular-rspack-compiler"
     },
     {
-      "path": "../../packages/compiler"
-    },
-    {
       "path": "../../testing/setup"
     },
     {

--- a/e2e/rsbuild-csr-less-e2e/tsconfig.json
+++ b/e2e/rsbuild-csr-less-e2e/tsconfig.json
@@ -30,9 +30,6 @@
       "path": "../../packages/angular-rspack-compiler"
     },
     {
-      "path": "../../packages/compiler"
-    },
-    {
       "path": "../../testing/setup"
     },
     {

--- a/e2e/rsbuild-csr-scss-e2e/tsconfig.json
+++ b/e2e/rsbuild-csr-scss-e2e/tsconfig.json
@@ -30,9 +30,6 @@
       "path": "../../packages/angular-rspack-compiler"
     },
     {
-      "path": "../../packages/compiler"
-    },
-    {
       "path": "../../testing/setup"
     },
     {

--- a/e2e/rsbuild-ssr-css-e2e/tsconfig.json
+++ b/e2e/rsbuild-ssr-css-e2e/tsconfig.json
@@ -30,9 +30,6 @@
       "path": "../../packages/angular-rspack-compiler"
     },
     {
-      "path": "../../packages/compiler"
-    },
-    {
       "path": "../../testing/setup"
     },
     {

--- a/packages/angular-rsbuild/package.json
+++ b/packages/angular-rsbuild/package.json
@@ -7,7 +7,7 @@
   ],
   "version": "19.0.0-alpha.29",
   "dependencies": {
-    "@ng-rspack/compiler": "workspace:*",
+    "@nx/angular-rspack-compiler": "workspace:*",
     "sass-embedded": "^1.79.3",
     "@rsbuild/plugin-sass": "^1.1.2",
     "@rsbuild/plugin-less": "^1.1.1",

--- a/packages/angular-rsbuild/src/lib/config/create-config.integration.test.ts
+++ b/packages/angular-rsbuild/src/lib/config/create-config.integration.test.ts
@@ -24,6 +24,7 @@ describe('createConfig', () => {
         root,
         inlineStylesExtension: 'scss',
         tsconfigPath: './tsconfig.app.json',
+        aot: true,
       },
     });
     expect(

--- a/packages/angular-rsbuild/src/lib/config/create-config.ts
+++ b/packages/angular-rsbuild/src/lib/config/create-config.ts
@@ -121,7 +121,7 @@ export function _createConfig(
           },
           define: {
             ...(isProd ? { ngDevMode: 'false' } : undefined),
-            ngJitMode: pluginOptions.jit, // @TODO: use normalizedOptions
+            ngJitMode: normalizedOptions.aot ? undefined : 'true', // @TODO: use normalizedOptions
           },
         },
         output: {
@@ -150,7 +150,7 @@ export function _createConfig(
                 define: {
                   ngServerMode: true,
                   ...(isProd ? { ngDevMode: 'false' } : undefined),
-                  ngJitMode: pluginOptions.jit, // @TODO: use normalizedOptions
+                  ngJitMode: normalizedOptions.aot ? undefined : 'true', // @TODO: use normalizedOptions
                 },
               },
               output: {

--- a/packages/angular-rsbuild/src/lib/models/normalize-options.ts
+++ b/packages/angular-rsbuild/src/lib/models/normalize-options.ts
@@ -1,4 +1,4 @@
-import { FileReplacement } from '@ng-rspack/compiler';
+import { FileReplacement } from '@nx/angular-rspack-compiler';
 import { PluginAngularOptions } from './plugin-options';
 import { join, resolve } from 'node:path';
 import { existsSync } from 'node:fs';
@@ -45,7 +45,7 @@ export const DEFAULT_PLUGIN_ANGULAR_OPTIONS: PluginAngularOptions = {
   assets: ['./public'],
   styles: ['./src/styles.css'],
   scripts: [],
-  jit: false,
+  aot: true,
   inlineStylesExtension: 'css',
   tsconfigPath: join(process.cwd(), 'tsconfig.app.json'),
   useTsProjectReferences: false,

--- a/packages/angular-rsbuild/src/lib/models/plugin-options.ts
+++ b/packages/angular-rsbuild/src/lib/models/plugin-options.ts
@@ -2,7 +2,7 @@ import type {
   FileReplacement,
   InlineStyleExtension,
   StylePreprocessorOptions,
-} from '@ng-rspack/compiler';
+} from '@nx/angular-rspack-compiler';
 
 export interface PluginAngularOptions {
   root: string;
@@ -15,7 +15,7 @@ export interface PluginAngularOptions {
   styles: string[];
   scripts: string[];
   fileReplacements: FileReplacement[];
-  jit: boolean;
+  aot: boolean;
   inlineStylesExtension: InlineStyleExtension;
   tsconfigPath: string;
   hasServer: boolean;

--- a/packages/angular-rsbuild/src/lib/plugin/plugin-angular.ts
+++ b/packages/angular-rsbuild/src/lib/plugin/plugin-angular.ts
@@ -3,7 +3,7 @@ import {
   StyleUrlsResolver,
   TemplateUrlsResolver,
   TS_ALL_EXT_REGEX,
-} from '@ng-rspack/compiler';
+} from '@nx/angular-rspack-compiler';
 import { PluginAngularOptions } from '../models/plugin-options';
 import { normalizeOptions } from '../models/normalize-options';
 import { dirname, normalize, resolve } from 'path';
@@ -30,7 +30,7 @@ export const pluginAngular = (
     const templateUrlsResolver = new TemplateUrlsResolver();
     const config = api.getRsbuildConfig();
 
-    if (pluginOptions.jit) {
+    if (!pluginOptions.aot) {
       api.modifyRsbuildConfig((config) => {
         config.plugins ??= [];
         config.plugins.push(pluginAngularJit());

--- a/packages/angular-rsbuild/src/lib/plugin/plugin-hoisted-js-transformer.ts
+++ b/packages/angular-rsbuild/src/lib/plugin/plugin-hoisted-js-transformer.ts
@@ -7,7 +7,7 @@ import {
   maxWorkers,
   setupCompilationWithParallelCompilation,
   PartialMessage,
-} from '@ng-rspack/compiler';
+} from '@nx/angular-rspack-compiler';
 import { PluginAngularOptions } from '../models/plugin-options';
 import { normalizeOptions } from '../models/normalize-options';
 
@@ -31,7 +31,7 @@ export const pluginHoistedJsTransformer = (
         sourcemap: false,
         thirdPartySourcemaps: false,
         advancedOptimizations: false,
-        jit: pluginOptions.jit,
+        jit: !pluginOptions.aot,
       },
       maxWorkers()
     );

--- a/packages/angular-rsbuild/tsconfig.json
+++ b/packages/angular-rsbuild/tsconfig.json
@@ -10,9 +10,6 @@
       "path": "../angular-rspack-compiler"
     },
     {
-      "path": "../compiler"
-    },
-    {
       "path": "../../testing/setup"
     },
     {

--- a/packages/angular-rsbuild/tsconfig.lib.json
+++ b/packages/angular-rsbuild/tsconfig.lib.json
@@ -24,9 +24,6 @@
       "path": "../angular-rspack-compiler/tsconfig.lib.json"
     },
     {
-      "path": "../compiler/tsconfig.lib.json"
-    },
-    {
       "path": "../../testing/setup/tsconfig.lib.json"
     }
   ],

--- a/packages/angular-rspack-compiler/src/compilation/setup-compilation.integration.test.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-compilation.integration.test.ts
@@ -121,7 +121,7 @@ describe('setupCompilation', () => {
       setupCompilation(rsBuildMockConfig, {
         root: '',
         tsconfigPath: 'irrelevant-if-tsconfig-is-in-rsbuild-config',
-        jit: false,
+        aot: true,
         inlineStylesExtension: 'css',
         fileReplacements: [],
       })
@@ -148,7 +148,7 @@ describe('setupCompilation', () => {
         {
           root: '',
           tsconfigPath: path.join(fixturesDir, 'tsconfig.other.mock.json'),
-          jit: false,
+          aot: true,
           inlineStylesExtension: 'css',
           fileReplacements: [],
         }

--- a/packages/angular-rspack-compiler/src/compilation/setup-compilation.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-compilation.ts
@@ -11,7 +11,7 @@ import { getSupportedBrowsers } from '@angular/build/private';
 export interface SetupCompilationOptions {
   root: string;
   tsconfigPath: string;
-  jit: boolean;
+  aot: boolean;
   inlineStylesExtension: InlineStyleExtension;
   fileReplacements: Array<FileReplacement>;
   useTsProjectReferences?: boolean;
@@ -81,7 +81,7 @@ export async function setupCompilation(
     false
   );
 
-  if (!options.jit) {
+  if (options.aot) {
     augmentHostWithResources(host, (code) => compileString(code).css, {
       inlineStylesExtension: options.inlineStylesExtension,
       isProd,

--- a/packages/angular-rspack-compiler/src/compilation/setup-compilation.unit.test.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-compilation.unit.test.ts
@@ -101,7 +101,7 @@ describe('setupCompilation', () => {
     ).resolves.toStrictEqual({
       compilerOptions: {
         inlineStylesExtension: 'css',
-        jit: false,
+        aot: true,
         tsconfigPath: expect.stringMatching(/tsconfig.angular.json$/),
         useTsProjectReferences: false,
         fileReplacements: [],
@@ -148,7 +148,7 @@ describe('setupCompilation', () => {
     expect(createIncrementalCompilerHostSpy).toHaveBeenCalledTimes(1);
     expect(createIncrementalCompilerHostSpy).toHaveBeenCalledWith({
       inlineStylesExtension: 'css',
-      jit: false,
+      aot: true,
       tsconfigPath: expect.stringMatching(/tsconfig.angular.json$/),
       useTsProjectReferences: false,
       fileReplacements: [],

--- a/packages/angular-rspack-compiler/src/compilation/setup-compilation.unit.test.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-compilation.unit.test.ts
@@ -38,7 +38,7 @@ describe('setupCompilation', () => {
 
   const pluginAngularOptions: SetupCompilationOptions = {
     tsconfigPath: 'tsconfig.angular.json',
-    jit: false,
+    aot: true,
     inlineStylesExtension: 'css',
     useTsProjectReferences: false,
     fileReplacements: [],
@@ -167,7 +167,7 @@ describe('setupCompilation', () => {
       async () =>
         await setupCompilation(rsBuildConfig, {
           ...pluginAngularOptions,
-          jit: true,
+          aot: false,
         })
     ).not.toThrow();
     expect(augmentHostWithResourcesSpy).not.toHaveBeenCalled();

--- a/packages/angular-rspack-compiler/src/compilation/setup-with-paralell-compilation.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-with-paralell-compilation.ts
@@ -14,7 +14,7 @@ export async function setupCompilationWithParallelCompilation(
   const { rootNames, compilerOptions, componentStylesheetBundler } =
     await setupCompilation(config, options);
   const parallelCompilation = new ParallelCompilation(
-    options.jit ?? false,
+    !options.aot,
     options.hasServer === false
   );
   const fileReplacements: Record<string, string> =

--- a/packages/angular-rspack-compiler/src/compilation/setup-with-paralell-compilation.unit.test.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-with-paralell-compilation.unit.test.ts
@@ -26,7 +26,7 @@ describe('setupCompilationWithParallelCompilation', () => {
         with: 'src/main.prod.ts',
       },
     ],
-    jit: false,
+    aot: true,
     inlineStylesExtension: 'css',
   };
 
@@ -102,7 +102,7 @@ describe('setupCompilationWithParallelCompilation', () => {
     await expect(() =>
       setupCompilationWithParallelCompilation(rsBuildConfig, {
         ...pluginAngularOptions,
-        jit: true,
+        aot: false,
         hasServer: false,
       })
     ).not.toThrow();
@@ -115,7 +115,7 @@ describe('setupCompilationWithParallelCompilation', () => {
     await expect(() =>
       setupCompilationWithParallelCompilation(rsBuildConfig, {
         ...pluginAngularOptions,
-        jit: true,
+        aot: false,
         hasServer: true,
       })
     ).not.toThrow();

--- a/packages/angular-rspack-compiler/src/models/compiler-plugin-options.ts
+++ b/packages/angular-rspack-compiler/src/models/compiler-plugin-options.ts
@@ -3,7 +3,7 @@ import { SourceFileCache } from '../utils/source-file-cache';
 export interface CompilerPluginOptions {
   sourcemap: boolean;
   tsconfig: string;
-  jit?: boolean;
+  aot?: boolean;
   /** Skip TypeScript compilation setup. This is useful to re-use the TypeScript compilation from another plugin. */
   noopTypeScriptCompilation?: boolean;
   advancedOptimizations?: boolean;

--- a/packages/angular-rspack/package.json
+++ b/packages/angular-rspack/package.json
@@ -49,7 +49,7 @@
     "sass-loader": "^16.0.2",
     "sass-embedded": "^1.79.3",
     "tslib": "^2.3.0",
-    "@ng-rspack/compiler": "workspace:*",
+    "@nx/angular-rspack-compiler": "workspace:*",
     "webpack-merge": "^6.0.1",
     "ws": "^8.18.0",
     "express": "4.21.1"

--- a/packages/angular-rspack/src/lib/config/create-config.ts
+++ b/packages/angular-rspack/src/lib/config/create-config.ts
@@ -7,7 +7,10 @@ import {
 import { merge as rspackMerge } from 'webpack-merge';
 import { join } from 'path';
 import { AngularRspackPluginOptions, normalizeOptions } from '../models';
-import { JS_ALL_EXT_REGEX, TS_ALL_EXT_REGEX } from '@ng-rspack/compiler';
+import {
+  JS_ALL_EXT_REGEX,
+  TS_ALL_EXT_REGEX,
+} from '@nx/angular-rspack-compiler';
 import { getStyleLoaders } from './style-config-utils';
 
 export function _createConfig(

--- a/packages/angular-rspack/src/lib/config/create-config.unit.test.ts
+++ b/packages/angular-rspack/src/lib/config/create-config.unit.test.ts
@@ -14,7 +14,7 @@ describe('createConfig', () => {
     assets: [],
     fileReplacements: [],
     scripts: [],
-    jit: false,
+    aot: true,
     hasServer: false,
     skipTypeChecking: false,
   };

--- a/packages/angular-rspack/src/lib/config/style-config-utils.ts
+++ b/packages/angular-rspack/src/lib/config/style-config-utils.ts
@@ -1,4 +1,4 @@
-import { StylePreprocessorOptions } from '@ng-rspack/compiler';
+import { StylePreprocessorOptions } from '@nx/angular-rspack-compiler';
 
 export function getIncludePathOptions(includePaths?: string[]) {
   if (!includePaths || includePaths.length === 0) {

--- a/packages/angular-rspack/src/lib/models/angular-rspack-plugin-options.ts
+++ b/packages/angular-rspack/src/lib/models/angular-rspack-plugin-options.ts
@@ -2,7 +2,7 @@ import type {
   FileReplacement,
   InlineStyleExtension,
   StylePreprocessorOptions,
-} from '@ng-rspack/compiler';
+} from '@nx/angular-rspack-compiler';
 
 export interface AngularRspackPluginOptions {
   root: string;

--- a/packages/angular-rspack/src/lib/models/angular-rspack-plugin-options.ts
+++ b/packages/angular-rspack/src/lib/models/angular-rspack-plugin-options.ts
@@ -15,7 +15,7 @@ export interface AngularRspackPluginOptions {
   styles: string[];
   scripts: string[];
   fileReplacements: FileReplacement[];
-  jit: boolean;
+  aot: boolean;
   inlineStylesExtension: InlineStyleExtension;
   tsconfigPath: string;
   hasServer: boolean;

--- a/packages/angular-rspack/src/lib/models/augmented-compilation.ts
+++ b/packages/angular-rspack/src/lib/models/augmented-compilation.ts
@@ -1,5 +1,5 @@
 import type { Compilation } from '@rspack/core';
-import type { JavaScriptTransformer } from '@ng-rspack/compiler';
+import type { JavaScriptTransformer } from '@nx/angular-rspack-compiler';
 
 export const NG_RSPACK_SYMBOL_NAME = 'NG_RSPACK_BUILD';
 

--- a/packages/angular-rspack/src/lib/models/normalize-options.ts
+++ b/packages/angular-rspack/src/lib/models/normalize-options.ts
@@ -1,4 +1,4 @@
-import { FileReplacement } from '@ng-rspack/compiler';
+import { FileReplacement } from '@nx/angular-rspack-compiler';
 import { AngularRspackPluginOptions } from './angular-rspack-plugin-options';
 import { join, resolve } from 'node:path';
 import { existsSync } from 'node:fs';

--- a/packages/angular-rspack/src/lib/models/normalize-options.ts
+++ b/packages/angular-rspack/src/lib/models/normalize-options.ts
@@ -54,7 +54,7 @@ export function normalizeOptions(
     styles: options.styles ?? ['./src/styles.css'],
     scripts: options.scripts ?? [],
     fileReplacements: resolveFileReplacements(fileReplacements, root),
-    jit: options.jit ?? false,
+    aot: options.aot ?? true,
     inlineStylesExtension: options.inlineStylesExtension ?? 'css',
     tsconfigPath: options.tsconfigPath ?? join(root, 'tsconfig.app.json'),
     hasServer: getHasServer({ server, ssrEntry, root }),

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
@@ -44,7 +44,7 @@ export class AngularRspackPlugin implements RspackPluginInstance {
         sourcemap: false,
         thirdPartySourcemaps: false,
         advancedOptimizations: true,
-        jit: this.#_options.jit,
+        jit: !this.#_options.aot,
       },
       maxWorkers()
     ) as unknown as ResolvedJavascriptTransformer;
@@ -206,7 +206,7 @@ export class AngularRspackPlugin implements RspackPluginInstance {
       },
       {
         root: this.#_options.root,
-        jit: this.#_options.jit,
+        aot: this.#_options.aot,
         tsconfigPath: tsconfigPath,
         inlineStylesExtension: this.#_options.inlineStylesExtension,
         fileReplacements: this.#_options.fileReplacements,

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
@@ -9,13 +9,13 @@ import {
   NG_RSPACK_SYMBOL_NAME,
   NgRspackCompilation,
 } from '../models';
-import { maxWorkers } from '@ng-rspack/compiler';
 import {
+  maxWorkers,
   buildAndAnalyzeWithParallelCompilation,
   JavaScriptTransformer,
   setupCompilationWithParallelCompilation,
   DiagnosticModes,
-} from '@ng-rspack/compiler';
+} from '@nx/angular-rspack-compiler';
 import { dirname, normalize, resolve } from 'path';
 import fs_1 from 'fs';
 

--- a/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.ts
@@ -1,7 +1,10 @@
 import type { LoaderContext } from '@rspack/core';
 import { normalize } from 'path';
 import { NG_RSPACK_SYMBOL_NAME, NgRspackCompilation } from '../../models';
-import { StyleUrlsResolver, TemplateUrlsResolver } from '@ng-rspack/compiler';
+import {
+  StyleUrlsResolver,
+  TemplateUrlsResolver,
+} from '@nx/angular-rspack-compiler';
 
 const styleUrlsResolver = new StyleUrlsResolver();
 const templateUrlsResolver = new TemplateUrlsResolver();

--- a/packages/angular-rspack/src/lib/plugins/ng-rspack.ts
+++ b/packages/angular-rspack/src/lib/plugins/ng-rspack.ts
@@ -62,7 +62,7 @@ export class NgRspackPlugin implements RspackPluginInstance {
     }
     new DefinePlugin({
       ngDevMode: isProduction ? 'false' : {},
-      ngJitMode: this.pluginOptions.jit ?? 'false',
+      ngJitMode: this.pluginOptions.aot ? 'false' : 'true',
       ngServerMode: this.pluginOptions.hasServer,
     }).apply(compiler);
     if (this.pluginOptions.assets) {

--- a/packages/angular-rspack/src/lib/plugins/ng-rspack.ts
+++ b/packages/angular-rspack/src/lib/plugins/ng-rspack.ts
@@ -62,7 +62,7 @@ export class NgRspackPlugin implements RspackPluginInstance {
     }
     new DefinePlugin({
       ngDevMode: isProduction ? 'false' : {},
-      ngJitMode: this.pluginOptions.aot ? 'false' : 'true',
+      ngJitMode: this.pluginOptions.aot ? undefined : 'true',
       ngServerMode: this.pluginOptions.hasServer,
     }).apply(compiler);
     if (this.pluginOptions.assets) {

--- a/packages/angular-rspack/tsconfig.json
+++ b/packages/angular-rspack/tsconfig.json
@@ -10,9 +10,6 @@
       "path": "../angular-rspack-compiler"
     },
     {
-      "path": "../compiler"
-    },
-    {
       "path": "../../testing/setup"
     },
     {

--- a/packages/angular-rspack/tsconfig.lib.json
+++ b/packages/angular-rspack/tsconfig.lib.json
@@ -24,9 +24,6 @@
       "path": "../angular-rspack-compiler/tsconfig.lib.json"
     },
     {
-      "path": "../compiler/tsconfig.lib.json"
-    },
-    {
       "path": "../../testing/setup/tsconfig.lib.json"
     }
   ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -435,9 +435,9 @@ importers:
       '@angular/ssr':
         specifier: '>=19.0.0 <20.0.0'
         version: 19.1.6(jiulpsphjxi2gglhkdvd6vtvui)
-      '@ng-rspack/compiler':
+      '@nx/angular-rspack-compiler':
         specifier: workspace:*
-        version: link:../compiler
+        version: link:../angular-rspack-compiler
       '@rsbuild/core':
         specifier: '>=1.0.5 <2.0.0'
         version: 1.2.12
@@ -472,9 +472,9 @@ importers:
       '@angular/ssr':
         specifier: '>=19.0.0 <20.0.0'
         version: 19.1.6(jiulpsphjxi2gglhkdvd6vtvui)
-      '@ng-rspack/compiler':
+      '@nx/angular-rspack-compiler':
         specifier: workspace:*
-        version: link:../compiler
+        version: link:../angular-rspack-compiler
       '@rspack/core':
         specifier: '>=1.0.5 <2.0.0'
         version: 1.2.6(@swc/helpers@0.5.15)


### PR DESCRIPTION
- feat(angular-rspack): rename jit to aot and invert
- feat(angular-rsbuild): rename jit to aot

## Current Behaviour
`jit` option is currently used to control whether to use aot or jit.


## Expected Behaviour
Rename to `aot` to match Angular's schema
