### PR TITLE
feat(angular-rspack,angular-rsbuild): rename tsconfigPath to tsConfig

### DIFF
--- a/e2e/fixtures/rspack-csr-css/rspack.config.js
+++ b/e2e/fixtures/rspack-csr-css/rspack.config.js
@@ -1,5 +1,6 @@
 module.exports = () => {
   if (global.NX_GRAPH_CREATION === undefined) {
+    const { join } = require('path');
     const { createConfig } = require('@nx/angular-rspack');
     return createConfig({
       options: {
@@ -11,7 +12,7 @@ module.exports = () => {
         polyfills: ['zone.js'],
         main: './src/main.ts',
         outputPath: './dist/browser',
-        tsConfig: './tsconfig.app.json',
+        tsConfig: join(__dirname, './tsconfig.app.json'),
         skipTypeChecking: false,
       },
     });

--- a/packages/angular-rsbuild/src/lib/config/create-config.integration.test.ts
+++ b/packages/angular-rsbuild/src/lib/config/create-config.integration.test.ts
@@ -23,7 +23,7 @@ describe('createConfig', () => {
       options: {
         root,
         inlineStylesExtension: 'scss',
-        tsconfigPath: './tsconfig.app.json',
+        tsConfig: './tsconfig.app.json',
         aot: true,
       },
     });
@@ -51,7 +51,7 @@ describe('createConfig', () => {
         server: './src/main.server.ts',
         ssrEntry: './src/server.ts',
         inlineStylesExtension: 'scss',
-        tsconfigPath: './tsconfig.app.json',
+        tsConfig: './tsconfig.app.json',
       },
     });
 

--- a/packages/angular-rsbuild/src/lib/config/create-config.ts
+++ b/packages/angular-rsbuild/src/lib/config/create-config.ts
@@ -79,7 +79,7 @@ export function _createConfig(
   const rsbuildPluginAngularConfig = defineConfig({
     root: normalizedOptions.root,
     source: {
-      tsconfigPath: normalizedOptions.tsconfigPath,
+      tsconfigPath: normalizedOptions.tsConfig,
     },
     plugins: [pluginHoistedJsTransformer(normalizedOptions), ...stylePlugins],
     mode: isProd ? 'production' : 'development',

--- a/packages/angular-rsbuild/src/lib/models/normalize-options.ts
+++ b/packages/angular-rsbuild/src/lib/models/normalize-options.ts
@@ -47,7 +47,7 @@ export const DEFAULT_PLUGIN_ANGULAR_OPTIONS: PluginAngularOptions = {
   scripts: [],
   aot: true,
   inlineStylesExtension: 'css',
-  tsconfigPath: join(process.cwd(), 'tsconfig.app.json'),
+  tsConfig: join(process.cwd(), 'tsconfig.app.json'),
   useTsProjectReferences: false,
   skipTypeChecking: false,
 };

--- a/packages/angular-rsbuild/src/lib/models/plugin-options.ts
+++ b/packages/angular-rsbuild/src/lib/models/plugin-options.ts
@@ -17,7 +17,7 @@ export interface PluginAngularOptions {
   fileReplacements: FileReplacement[];
   aot: boolean;
   inlineStylesExtension: InlineStyleExtension;
-  tsconfigPath: string;
+  tsConfig: string;
   hasServer: boolean;
   skipTypeChecking: boolean;
   useTsProjectReferences?: boolean;

--- a/packages/angular-rspack-compiler/src/compilation/setup-compilation.integration.test.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-compilation.integration.test.ts
@@ -120,7 +120,7 @@ describe('setupCompilation', () => {
     await expect(
       setupCompilation(rsBuildMockConfig, {
         root: '',
-        tsconfigPath: 'irrelevant-if-tsconfig-is-in-rsbuild-config',
+        tsConfig: 'irrelevant-if-tsconfig-is-in-rsbuild-config',
         aot: true,
         inlineStylesExtension: 'css',
         fileReplacements: [],
@@ -147,7 +147,7 @@ describe('setupCompilation', () => {
         },
         {
           root: '',
-          tsconfigPath: path.join(fixturesDir, 'tsconfig.other.mock.json'),
+          tsConfig: path.join(fixturesDir, 'tsconfig.other.mock.json'),
           aot: true,
           inlineStylesExtension: 'css',
           fileReplacements: [],

--- a/packages/angular-rspack-compiler/src/compilation/setup-compilation.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-compilation.ts
@@ -10,7 +10,7 @@ import { getSupportedBrowsers } from '@angular/build/private';
 
 export interface SetupCompilationOptions {
   root: string;
-  tsconfigPath: string;
+  tsConfig: string;
   aot: boolean;
   inlineStylesExtension: InlineStyleExtension;
   fileReplacements: Array<FileReplacement>;
@@ -42,7 +42,7 @@ export async function setupCompilation(
 
   const { readConfiguration } = await loadCompilerCli();
   const { options: tsCompilerOptions, rootNames } = readConfiguration(
-    config.source?.tsconfigPath ?? options.tsconfigPath,
+    config.source?.tsconfigPath ?? options.tsConfig,
     {
       ...DEFAULT_NG_COMPILER_OPTIONS,
       ...(options.useTsProjectReferences

--- a/packages/angular-rspack-compiler/src/compilation/setup-compilation.unit.test.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-compilation.unit.test.ts
@@ -37,7 +37,7 @@ describe('setupCompilation', () => {
   };
 
   const pluginAngularOptions: SetupCompilationOptions = {
-    tsconfigPath: 'tsconfig.angular.json',
+    tsConfig: 'tsconfig.angular.json',
     aot: true,
     inlineStylesExtension: 'css',
     useTsProjectReferences: false,
@@ -102,7 +102,7 @@ describe('setupCompilation', () => {
       compilerOptions: {
         inlineStylesExtension: 'css',
         aot: true,
-        tsconfigPath: expect.stringMatching(/tsconfig.angular.json$/),
+        tsConfig: expect.stringMatching(/tsconfig.angular.json$/),
         useTsProjectReferences: false,
         fileReplacements: [],
       },
@@ -149,7 +149,7 @@ describe('setupCompilation', () => {
     expect(createIncrementalCompilerHostSpy).toHaveBeenCalledWith({
       inlineStylesExtension: 'css',
       aot: true,
-      tsconfigPath: expect.stringMatching(/tsconfig.angular.json$/),
+      tsConfig: expect.stringMatching(/tsconfig.angular.json$/),
       useTsProjectReferences: false,
       fileReplacements: [],
     });

--- a/packages/angular-rspack-compiler/src/compilation/setup-with-paralell-compilation.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-with-paralell-compilation.ts
@@ -25,7 +25,7 @@ export async function setupCompilationWithParallelCompilation(
 
   try {
     await parallelCompilation.initialize(
-      config.source?.tsconfigPath ?? options.tsconfigPath,
+      config.source?.tsconfigPath ?? options.tsConfig,
       {
         ...compilerOptions,
         fileReplacements,

--- a/packages/angular-rspack-compiler/src/compilation/setup-with-paralell-compilation.unit.test.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-with-paralell-compilation.unit.test.ts
@@ -19,7 +19,7 @@ describe('setupCompilationWithParallelCompilation', () => {
   };
 
   const pluginAngularOptions: SetupCompilationOptions = {
-    tsconfigPath: 'tsconfig.angular.json',
+    tsConfig: 'tsconfig.angular.json',
     fileReplacements: [
       {
         replace: 'src/main.ts',

--- a/packages/angular-rspack/src/lib/config/create-config.ts
+++ b/packages/angular-rspack/src/lib/config/create-config.ts
@@ -36,7 +36,7 @@ export function _createConfig(
       mainFields: ['es2020', 'es2015', 'browser', 'module', 'main'],
       conditionNames: ['es2020', 'es2015', '...'],
       tsConfig: {
-        configFile: normalizedOptions.tsconfigPath,
+        configFile: normalizedOptions.tsConfig,
       },
     },
     experiments: {

--- a/packages/angular-rspack/src/lib/config/create-config.unit.test.ts
+++ b/packages/angular-rspack/src/lib/config/create-config.unit.test.ts
@@ -7,7 +7,7 @@ describe('createConfig', () => {
     root: '',
     browser: './src/main.ts',
     index: './src/index.html',
-    tsconfigPath: './tsconfig.base.json',
+    tsConfig: './tsconfig.base.json',
     inlineStylesExtension: 'css',
     polyfills: [],
     styles: [],

--- a/packages/angular-rspack/src/lib/models/angular-rspack-plugin-options.ts
+++ b/packages/angular-rspack/src/lib/models/angular-rspack-plugin-options.ts
@@ -17,7 +17,7 @@ export interface AngularRspackPluginOptions {
   fileReplacements: FileReplacement[];
   aot: boolean;
   inlineStylesExtension: InlineStyleExtension;
-  tsconfigPath: string;
+  tsConfig: string;
   hasServer: boolean;
   skipTypeChecking: boolean;
   useTsProjectReferences?: boolean;

--- a/packages/angular-rspack/src/lib/models/normalize-options.ts
+++ b/packages/angular-rspack/src/lib/models/normalize-options.ts
@@ -56,7 +56,7 @@ export function normalizeOptions(
     fileReplacements: resolveFileReplacements(fileReplacements, root),
     aot: options.aot ?? true,
     inlineStylesExtension: options.inlineStylesExtension ?? 'css',
-    tsconfigPath: options.tsconfigPath ?? join(root, 'tsconfig.app.json'),
+    tsConfig: options.tsConfig ?? join(root, 'tsconfig.app.json'),
     hasServer: getHasServer({ server, ssrEntry, root }),
     skipTypeChecking: options.skipTypeChecking ?? false,
     useTsProjectReferences: options.useTsProjectReferences ?? false,

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
@@ -197,7 +197,7 @@ export class AngularRspackPlugin implements RspackPluginInstance {
       ? typeof tsConfig === 'string'
         ? tsConfig
         : tsConfig.configFile
-      : this.#_options.tsconfigPath;
+      : this.#_options.tsConfig;
     this.#angularCompilation = await setupCompilationWithParallelCompilation(
       {
         source: {
@@ -207,7 +207,7 @@ export class AngularRspackPlugin implements RspackPluginInstance {
       {
         root: this.#_options.root,
         aot: this.#_options.aot,
-        tsconfigPath: tsconfigPath,
+        tsConfig: tsconfigPath,
         inlineStylesExtension: this.#_options.inlineStylesExtension,
         fileReplacements: this.#_options.fileReplacements,
         useTsProjectReferences: this.#_options.useTsProjectReferences,


### PR DESCRIPTION
## Current Behaviour

`tsconfigPath` is currently used to handle specifying a tsconfig file.

## Expected Behaviour

`tsConfig` should be used to handle specifying a tsconfig file to match Angular's schema
