### PR TITLE
feat(angular-rspack,angular-rsbuild): rename inlineStylesExtension to inlineStyleLanguage

### DIFF
--- a/apps/docs/rsbuild.config.ts
+++ b/apps/docs/rsbuild.config.ts
@@ -4,7 +4,7 @@ const options = {
   browser: './src/main.ts',
   server: './src/main.server.ts',
   ssrEntry: './src/server.ts',
-  inlineStylesExtension: 'scss' as any,
+  inlineStyleLanguage: 'scss' as any,
   styles: ['./src/styles.scss', './src/hljs.theme.scss'],
   skipTypeChecking: true,
 };

--- a/packages/angular-rsbuild/src/lib/config/create-config.integration.test.ts
+++ b/packages/angular-rsbuild/src/lib/config/create-config.integration.test.ts
@@ -22,7 +22,7 @@ describe('createConfig', () => {
     const config = createConfig({
       options: {
         root,
-        inlineStylesExtension: 'scss',
+        inlineStyleLanguage: 'scss',
         tsConfig: './tsconfig.app.json',
         aot: true,
       },
@@ -50,7 +50,7 @@ describe('createConfig', () => {
         root,
         server: './src/main.server.ts',
         ssrEntry: './src/server.ts',
-        inlineStylesExtension: 'scss',
+        inlineStyleLanguage: 'scss',
         tsConfig: './tsconfig.app.json',
       },
     });

--- a/packages/angular-rsbuild/src/lib/config/create-config.ts
+++ b/packages/angular-rsbuild/src/lib/config/create-config.ts
@@ -30,8 +30,8 @@ export function _createConfig(
   const stylePlugins: RsbuildPlugin[] = [];
 
   if (
-    normalizedOptions.inlineStylesExtension === 'scss' ||
-    normalizedOptions.inlineStylesExtension === 'sass'
+    normalizedOptions.inlineStyleLanguage === 'scss' ||
+    normalizedOptions.inlineStyleLanguage === 'sass'
   ) {
     if (
       normalizedOptions.stylePreprocessorOptions?.includePaths ||
@@ -51,7 +51,7 @@ export function _createConfig(
     } else {
       stylePlugins.push(pluginSass());
     }
-  } else if (normalizedOptions.inlineStylesExtension === 'less') {
+  } else if (normalizedOptions.inlineStyleLanguage === 'less') {
     if (normalizedOptions.stylePreprocessorOptions?.includePaths) {
       stylePlugins.push(
         pluginLess({

--- a/packages/angular-rsbuild/src/lib/models/normalize-options.ts
+++ b/packages/angular-rsbuild/src/lib/models/normalize-options.ts
@@ -46,7 +46,7 @@ export const DEFAULT_PLUGIN_ANGULAR_OPTIONS: PluginAngularOptions = {
   styles: ['./src/styles.css'],
   scripts: [],
   aot: true,
-  inlineStylesExtension: 'css',
+  inlineStyleLanguage: 'css',
   tsConfig: join(process.cwd(), 'tsconfig.app.json'),
   useTsProjectReferences: false,
   skipTypeChecking: false,

--- a/packages/angular-rsbuild/src/lib/models/plugin-options.ts
+++ b/packages/angular-rsbuild/src/lib/models/plugin-options.ts
@@ -1,6 +1,6 @@
 import type {
   FileReplacement,
-  InlineStyleExtension,
+  InlineStyleLanguage,
   StylePreprocessorOptions,
 } from '@nx/angular-rspack-compiler';
 
@@ -16,7 +16,7 @@ export interface PluginAngularOptions {
   scripts: string[];
   fileReplacements: FileReplacement[];
   aot: boolean;
-  inlineStylesExtension: InlineStyleExtension;
+  inlineStyleLanguage: InlineStyleLanguage;
   tsConfig: string;
   hasServer: boolean;
   skipTypeChecking: boolean;

--- a/packages/angular-rspack-compiler/src/compilation/augments.ts
+++ b/packages/angular-rspack-compiler/src/compilation/augments.ts
@@ -27,7 +27,7 @@ import * as ts from 'typescript';
 import { type CompilerHost as AngularCompilerHost } from '@angular/compiler-cli';
 import { normalize } from 'path';
 import { createHash } from 'node:crypto';
-import { InlineStyleExtension } from '../models';
+import { InlineStyleLanguage } from '../models';
 
 /**
  *
@@ -43,7 +43,7 @@ export function augmentHostWithResources(
     options?: { ssr?: boolean }
   ) => string | null,
   options: {} & {
-    inlineStylesExtension?: InlineStyleExtension;
+    inlineStylesExtension?: InlineStyleLanguage;
     isProd?: boolean;
   } = {}
 ) {

--- a/packages/angular-rspack-compiler/src/compilation/setup-compilation.integration.test.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-compilation.integration.test.ts
@@ -122,7 +122,7 @@ describe('setupCompilation', () => {
         root: '',
         tsConfig: 'irrelevant-if-tsconfig-is-in-rsbuild-config',
         aot: true,
-        inlineStylesExtension: 'css',
+        inlineStyleLanguage: 'css',
         fileReplacements: [],
       })
     ).resolves.toStrictEqual(
@@ -149,7 +149,7 @@ describe('setupCompilation', () => {
           root: '',
           tsConfig: path.join(fixturesDir, 'tsconfig.other.mock.json'),
           aot: true,
-          inlineStylesExtension: 'css',
+          inlineStyleLanguage: 'css',
           fileReplacements: [],
         }
       )

--- a/packages/angular-rspack-compiler/src/compilation/setup-compilation.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-compilation.ts
@@ -2,7 +2,7 @@ import { RsbuildConfig } from '@rsbuild/core';
 import * as ts from 'typescript';
 import { compileString } from 'sass-embedded';
 import { augmentHostWithResources } from './augments';
-import { InlineStyleExtension, FileReplacement } from '../models';
+import { InlineStyleLanguage, FileReplacement } from '../models';
 import { loadCompilerCli } from '../utils';
 import { ComponentStylesheetBundler } from '@angular/build/src/tools/esbuild/angular/component-stylesheets';
 import { transformSupportedBrowsersToTargets } from '../utils/targets-from-browsers';
@@ -12,7 +12,7 @@ export interface SetupCompilationOptions {
   root: string;
   tsConfig: string;
   aot: boolean;
-  inlineStylesExtension: InlineStyleExtension;
+  inlineStyleLanguage: InlineStyleLanguage;
   fileReplacements: Array<FileReplacement>;
   useTsProjectReferences?: boolean;
   hasServer?: boolean;
@@ -77,13 +77,13 @@ export async function setupCompilation(
         })
       ),
     },
-    options.inlineStylesExtension,
+    options.inlineStyleLanguage,
     false
   );
 
   if (options.aot) {
     augmentHostWithResources(host, (code) => compileString(code).css, {
-      inlineStylesExtension: options.inlineStylesExtension,
+      inlineStylesExtension: options.inlineStyleLanguage,
       isProd,
     });
   }

--- a/packages/angular-rspack-compiler/src/compilation/setup-compilation.unit.test.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-compilation.unit.test.ts
@@ -39,7 +39,7 @@ describe('setupCompilation', () => {
   const pluginAngularOptions: SetupCompilationOptions = {
     tsConfig: 'tsconfig.angular.json',
     aot: true,
-    inlineStylesExtension: 'css',
+    inlineStyleLanguage: 'css',
     useTsProjectReferences: false,
     fileReplacements: [],
   };
@@ -100,7 +100,7 @@ describe('setupCompilation', () => {
       setupCompilation(rsBuildConfig, pluginAngularOptions)
     ).resolves.toStrictEqual({
       compilerOptions: {
-        inlineStylesExtension: 'css',
+        inlineStyleLanguage: 'css',
         aot: true,
         tsConfig: expect.stringMatching(/tsconfig.angular.json$/),
         useTsProjectReferences: false,
@@ -147,7 +147,7 @@ describe('setupCompilation', () => {
     ).resolves.not.toThrow();
     expect(createIncrementalCompilerHostSpy).toHaveBeenCalledTimes(1);
     expect(createIncrementalCompilerHostSpy).toHaveBeenCalledWith({
-      inlineStylesExtension: 'css',
+      inlineStyleLanguage: 'css',
       aot: true,
       tsConfig: expect.stringMatching(/tsconfig.angular.json$/),
       useTsProjectReferences: false,

--- a/packages/angular-rspack-compiler/src/compilation/setup-with-paralell-compilation.unit.test.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-with-paralell-compilation.unit.test.ts
@@ -27,7 +27,7 @@ describe('setupCompilationWithParallelCompilation', () => {
       },
     ],
     aot: true,
-    inlineStylesExtension: 'css',
+    inlineStyleLanguage: 'css',
   };
 
   const initializeSpy = vi

--- a/packages/angular-rspack-compiler/src/models/index.ts
+++ b/packages/angular-rspack-compiler/src/models/index.ts
@@ -2,7 +2,7 @@ import { JavaScriptTransformer } from '@angular/build/src/tools/esbuild/javascri
 import { ParallelCompilation } from '@angular/build/src/tools/angular/compilation/parallel-compilation';
 export { ParallelCompilation, JavaScriptTransformer };
 
-export * from './inline-style-extension';
+export * from './inline-style-language';
 export * from './file-replacement';
 export * from './style-preprocessor-options';
 

--- a/packages/angular-rspack-compiler/src/models/inline-style-extension.ts
+++ b/packages/angular-rspack-compiler/src/models/inline-style-extension.ts
@@ -1,1 +1,0 @@
-export type InlineStyleExtension = 'css' | 'scss' | 'sass' | 'less';

--- a/packages/angular-rspack-compiler/src/models/inline-style-language.ts
+++ b/packages/angular-rspack-compiler/src/models/inline-style-language.ts
@@ -1,0 +1,1 @@
+export type InlineStyleLanguage = 'css' | 'scss' | 'sass' | 'less';

--- a/packages/angular-rspack/src/lib/config/create-config.unit.test.ts
+++ b/packages/angular-rspack/src/lib/config/create-config.unit.test.ts
@@ -8,7 +8,7 @@ describe('createConfig', () => {
     browser: './src/main.ts',
     index: './src/index.html',
     tsConfig: './tsconfig.base.json',
-    inlineStylesExtension: 'css',
+    inlineStyleLanguage: 'css',
     polyfills: [],
     styles: [],
     assets: [],

--- a/packages/angular-rspack/src/lib/models/angular-rspack-plugin-options.ts
+++ b/packages/angular-rspack/src/lib/models/angular-rspack-plugin-options.ts
@@ -1,6 +1,6 @@
 import type {
   FileReplacement,
-  InlineStyleExtension,
+  InlineStyleLanguage,
   StylePreprocessorOptions,
 } from '@nx/angular-rspack-compiler';
 
@@ -16,7 +16,7 @@ export interface AngularRspackPluginOptions {
   scripts: string[];
   fileReplacements: FileReplacement[];
   aot: boolean;
-  inlineStylesExtension: InlineStyleExtension;
+  inlineStyleLanguage: InlineStyleLanguage;
   tsConfig: string;
   hasServer: boolean;
   skipTypeChecking: boolean;

--- a/packages/angular-rspack/src/lib/models/normalize-options.ts
+++ b/packages/angular-rspack/src/lib/models/normalize-options.ts
@@ -55,7 +55,7 @@ export function normalizeOptions(
     scripts: options.scripts ?? [],
     fileReplacements: resolveFileReplacements(fileReplacements, root),
     aot: options.aot ?? true,
-    inlineStylesExtension: options.inlineStylesExtension ?? 'css',
+    inlineStyleLanguage: options.inlineStyleLanguage ?? 'css',
     tsConfig: options.tsConfig ?? join(root, 'tsconfig.app.json'),
     hasServer: getHasServer({ server, ssrEntry, root }),
     skipTypeChecking: options.skipTypeChecking ?? false,

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
@@ -208,7 +208,7 @@ export class AngularRspackPlugin implements RspackPluginInstance {
         root: this.#_options.root,
         aot: this.#_options.aot,
         tsConfig: tsconfigPath,
-        inlineStylesExtension: this.#_options.inlineStylesExtension,
+        inlineStyleLanguage: this.#_options.inlineStyleLanguage,
         fileReplacements: this.#_options.fileReplacements,
         useTsProjectReferences: this.#_options.useTsProjectReferences,
         hasServer: this.#_options.hasServer,


### PR DESCRIPTION
## Current Behaviour
The property `inlineStylesExtension` is currently used to determine what style processor to use

## Expected Behaviour
Rename the property to `inlineStyleLanguage` to match the angular schema
