### PR TITLE
test(angular-rspack): add unit tests for angular loader

### DIFF
--- a/packages/angular-rspack/src/lib/models/augmented-compilation.ts
+++ b/packages/angular-rspack/src/lib/models/augmented-compilation.ts
@@ -5,7 +5,7 @@ export const NG_RSPACK_SYMBOL_NAME = 'NG_RSPACK_BUILD';
 
 export type NG_RSPACK_COMPILATION_STATE = {
   javascriptTransformer: JavaScriptTransformer;
-  typescriptFileCache: Map<string, string>;
+  typescriptFileCache: Map<string, string | Buffer>;
 };
 export type NgRspackCompilation = Compilation & {
   [NG_RSPACK_SYMBOL_NAME]: () => NG_RSPACK_COMPILATION_STATE;

--- a/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.ts
@@ -20,7 +20,7 @@ export default function loader(
   const {
     styleUrlsResolver = _styleUrlsResolver,
     templateUrlsResolver = _templateUrlsResolver,
-  } = opt ?? {};
+  } = opt || {};
   const callback = this.async();
   if (
     (this._compilation as NgRspackCompilation)[NG_RSPACK_SYMBOL_NAME] ===

--- a/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.ts
@@ -6,10 +6,21 @@ import {
   TemplateUrlsResolver,
 } from '@nx/angular-rspack-compiler';
 
-const styleUrlsResolver = new StyleUrlsResolver();
-const templateUrlsResolver = new TemplateUrlsResolver();
+const _styleUrlsResolver = new StyleUrlsResolver();
+const _templateUrlsResolver = new TemplateUrlsResolver();
 
-export default function loader(this: LoaderContext<unknown>, content: string) {
+export default function loader(
+  this: LoaderContext<unknown>,
+  content: string,
+  opt?: {
+    styleUrlsResolver: StyleUrlsResolver;
+    templateUrlsResolver: TemplateUrlsResolver;
+  }
+) {
+  const {
+    styleUrlsResolver = _styleUrlsResolver,
+    templateUrlsResolver = _templateUrlsResolver,
+  } = opt || {};
   const callback = this.async();
   if (
     (this._compilation as NgRspackCompilation)[NG_RSPACK_SYMBOL_NAME] ===

--- a/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.ts
@@ -20,7 +20,7 @@ export default function loader(
   const {
     styleUrlsResolver = _styleUrlsResolver,
     templateUrlsResolver = _templateUrlsResolver,
-  } = opt || {};
+  } = opt ?? {};
   const callback = this.async();
   if (
     (this._compilation as NgRspackCompilation)[NG_RSPACK_SYMBOL_NAME] ===

--- a/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.unit.test.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.unit.test.ts
@@ -6,7 +6,7 @@ import type { LoaderContext } from '@rspack/core';
 class StyleUrlsResolverMock {
   constructor(private cb: (content: string) => string) {}
 
-  resolve(content: string, id: string): string[] {
+  resolve(content: string, _: string): string[] {
     return [this.cb(content)];
   }
 }
@@ -14,7 +14,7 @@ class StyleUrlsResolverMock {
 class TemplateUrlsResolverMock {
   constructor(private cb: (content: string) => string) {}
 
-  resolve(content: string, id: string): string[] {
+  resolve(content: string, _: string): string[] {
     return [this.cb(content)];
   }
 }

--- a/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.unit.test.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.unit.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, vi } from 'vitest';
+import { default as angularTransformLoader } from './angular-transform.loader';
+import { NG_RSPACK_SYMBOL_NAME, NgRspackCompilation } from '../../models';
+import type { LoaderContext } from '@rspack/core';
+
+class StyleUrlsResolverMock {
+  constructor(private cb: (content: string) => string) {}
+
+  resolve(content: string, id: string): string[] {
+    return [this.cb(content)];
+  }
+}
+
+class TemplateUrlsResolverMock {
+  constructor(private cb: (content: string) => string) {}
+
+  resolve(content: string, id: string): string[] {
+    return [this.cb(content)];
+  }
+}
+
+describe('angular-transform.loader', () => {
+  const callback = vi.fn();
+  const addDependency = vi.fn();
+  const typescriptFileCache = new Map<string, string | Buffer>();
+  const _compilation = {
+    [NG_RSPACK_SYMBOL_NAME]: () => ({
+      typescriptFileCache,
+    }),
+  } as unknown as NgRspackCompilation;
+  const thisValue = {
+    async: vi.fn(() => callback),
+    _compilation: {},
+  } as unknown as LoaderContext<unknown>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return content when NG_RSPACK_SYMBOL_NAME is undefined', () => {
+    angularTransformLoader.call(thisValue, 'content');
+    expect(callback).toHaveBeenCalledWith(null, 'content');
+  });
+
+  it('should add dependencies for resolved template and style URLs', () => {
+    angularTransformLoader.call(
+      {
+        ...thisValue,
+        _compilation,
+        resourcePath: '/home/projects/analog/src/app/app.component.ts',
+        addDependency,
+      },
+      '@Component()',
+      {
+        templateUrlsResolver: new TemplateUrlsResolverMock(
+          () =>
+            './app.component.html|/home/projects/analog/src/app/app.component.html'
+        ),
+        styleUrlsResolver: new StyleUrlsResolverMock(
+          () =>
+            './app.component.css|/home/projects/analog/src/app/app.component.css'
+        ),
+      } as any
+    );
+
+    expect(addDependency).toHaveBeenCalledTimes(2);
+    expect(addDependency).toHaveBeenNthCalledWith(
+      1,
+      '/home/projects/analog/src/app/app.component.html'
+    );
+    expect(addDependency).toHaveBeenNthCalledWith(
+      2,
+      '/home/projects/analog/src/app/app.component.css'
+    );
+  });
+
+  it('should return content when typescriptFileCache does not contain normalizedRequest', () => {
+    angularTransformLoader.call(
+      {
+        ...thisValue,
+        _compilation,
+        resourcePath: '/path/to/file.ts',
+      },
+      'content'
+    );
+
+    expect(callback).toHaveBeenCalledWith(null, 'content');
+  });
+
+  it('should return content when typescriptFileCache does contain string', () => {
+    typescriptFileCache.set(
+      '/home/projects/analog/src/app/app.component.ts',
+      'cached content'
+    );
+
+    angularTransformLoader.call(
+      {
+        ...thisValue,
+        _compilation,
+        resourcePath: '/home/projects/analog/src/app/app.component.ts',
+      },
+      '@Component()'
+    );
+
+    expect(callback).toHaveBeenCalledWith(null, 'cached content');
+  });
+
+  it('should return content when typescriptFileCache does contain Buffer', () => {
+    typescriptFileCache.set(
+      '/home/projects/analog/src/app/app.component.ts',
+      Buffer.from('cached content')
+    );
+
+    angularTransformLoader.call(
+      {
+        ...thisValue,
+        _compilation,
+        resourcePath: '/home/projects/analog/src/app/app.component.ts',
+      },
+      '@Component()'
+    );
+
+    expect(callback).toHaveBeenCalledWith(null, Buffer.from('cached content'));
+  });
+});

--- a/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.unit.test.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.unit.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, vi } from 'vitest';
 import { default as angularTransformLoader } from './angular-transform.loader';
-import { NG_RSPACK_SYMBOL_NAME, NgRspackCompilation } from '../../models';
+import { NG_RSPACK_SYMBOL_NAME, type NgRspackCompilation } from '../../models';
 import type { LoaderContext } from '@rspack/core';
 
 class StyleUrlsResolverMock {


### PR DESCRIPTION
This PR includes: 
- nonbreaking adoptions of the loader function to be able to test the cache
- refinement of types
- unit tests for `angular-transform.loader.ts`