### PR TITLE
feat(angular-rspack,angular-rsbuild): rename ssrEntry to ssr.entry

### DIFF
--- a/apps/docs/rsbuild.config.ts
+++ b/apps/docs/rsbuild.config.ts
@@ -3,7 +3,9 @@ import { pluginSass } from '@rsbuild/plugin-sass';
 const options = {
   browser: './src/main.ts',
   server: './src/main.server.ts',
-  ssrEntry: './src/server.ts',
+  ssr: {
+    entry: './src/server.ts',
+  },
   inlineStyleLanguage: 'scss' as any,
   styles: ['./src/styles.scss', './src/hljs.theme.scss'],
   skipTypeChecking: true,

--- a/e2e/fixtures/rsbuild-ssr-css/rsbuild.config.ts
+++ b/e2e/fixtures/rsbuild-ssr-css/rsbuild.config.ts
@@ -5,7 +5,7 @@ export default () => {
       options: {
         browser: './src/main.ts',
         server: './src/main.server.ts',
-        ssrEntry: './src/server.ts',
+        ssr: { entry: './src/server.ts' },
         inlineStylesExtension: 'css',
       },
     });

--- a/e2e/fixtures/rspack-ssr-css/rspack.config.js
+++ b/e2e/fixtures/rspack-ssr-css/rspack.config.js
@@ -5,7 +5,7 @@ module.exports = () => {
       options: {
         browser: './src/main.ts',
         server: './src/main.server.ts',
-        ssrEntry: './src/server.ts',
+        ssr: { entry: './src/server.ts' },
       },
     });
   }

--- a/packages/angular-rsbuild/src/lib/config/create-config.ts
+++ b/packages/angular-rsbuild/src/lib/config/create-config.ts
@@ -151,7 +151,7 @@ export function _createConfig(
               source: {
                 preEntry: [...serverPolyfills],
                 entry: {
-                  server: normalizedOptions.ssrEntry!,
+                  server: (normalizedOptions.ssr as { entry: string }).entry,
                 },
                 define: {
                   ngServerMode: true,

--- a/packages/angular-rsbuild/src/lib/config/create-config.unit.test.ts
+++ b/packages/angular-rsbuild/src/lib/config/create-config.unit.test.ts
@@ -50,6 +50,7 @@ describe('createConfig', () => {
     argvSpy.mockReturnValue(['irrelevant', 'irrelevant', 'dev']);
     normalizeOptionsSpy.mockReturnValue({
       ...DEFAULT_PLUGIN_ANGULAR_OPTIONS,
+      ssr: { entry: 'main.ts' },
       hasServer: true,
     });
 

--- a/packages/angular-rsbuild/src/lib/models/normalize-options.unit.test.ts
+++ b/packages/angular-rsbuild/src/lib/models/normalize-options.unit.test.ts
@@ -56,10 +56,10 @@ describe('getHasServer', () => {
     );
   });
 
-  it('should return true if both server and ssrEntry files exist', () => {
+  it('should return true if both server and ssr.entry files exist', () => {
     const result = getHasServer({
       server: 'server.js',
-      ssrEntry: 'ssr-entry.js',
+      ssr: { entry: 'ssr-entry.js' },
       root: MEMFS_VOLUME,
     });
 
@@ -68,14 +68,14 @@ describe('getHasServer', () => {
 
   it('should return false if server file is not provides', () => {
     const result = getHasServer({
-      ssrEntry: 'ssr-entry.js',
+      ssr: { entry: 'ssr-entry.js' },
       root: '/project-root',
     });
 
     expect(result).toBe(false);
   });
 
-  it('should return false if ssrEntry file is not provides', () => {
+  it('should return false if ssr.entry file is not provides', () => {
     const result = getHasServer({
       server: 'server.js',
       root: '/project-root',
@@ -95,27 +95,27 @@ describe('getHasServer', () => {
   it('should return false if server file does not exist', () => {
     const result = getHasServer({
       server: 'non-existing-server.js',
-      ssrEntry: 'ssr-entry.js',
+      ssr: { entry: 'ssr-entry.js' },
       root: '/project-root',
     });
 
     expect(result).toBe(false);
   });
 
-  it('should return false if ssrEntry file does not exist', () => {
+  it('should return false if ssr.entry file does not exist', () => {
     const result = getHasServer({
       server: 'server.js',
-      ssrEntry: 'non-existing-ssr-entry.js',
+      ssr: { entry: 'non-existing-ssr-entry.js' },
       root: '/project-root',
     });
 
     expect(result).toBe(false);
   });
 
-  it('should return false if neither server nor ssrEntry exists', () => {
+  it('should return false if neither server nor ssr.entry exists', () => {
     const result = getHasServer({
       server: 'non-existing-server.js',
-      ssrEntry: 'non-existing-ssr-entry.js',
+      ssr: { entry: 'non-existing-ssr-entry.js' },
       root: '/project-root',
     });
 
@@ -165,7 +165,7 @@ describe('normalizeOptions', () => {
     expect(
       normalizeOptions({
         server: 'server.js',
-        ssrEntry: 'ssr-entry.js',
+        ssr: { entry: 'ssr-entry.js' },
         root: MEMFS_VOLUME,
       }).hasServer
     ).toStrictEqual(true);

--- a/packages/angular-rsbuild/src/lib/models/plugin-options.ts
+++ b/packages/angular-rsbuild/src/lib/models/plugin-options.ts
@@ -19,7 +19,12 @@ export interface PluginAngularOptions {
   index: string;
   browser: string;
   server?: string;
-  ssrEntry?: string;
+  ssr?:
+    | boolean
+    | {
+        entry: string;
+        experimentalPlatform?: 'node' | 'neutral';
+      };
   polyfills: string[];
   assets: string[];
   styles: string[];

--- a/packages/angular-rspack/src/lib/config/create-config.ts
+++ b/packages/angular-rspack/src/lib/config/create-config.ts
@@ -98,7 +98,7 @@ export function _createConfig(
       target: 'node',
       entry: {
         server: {
-          import: [normalizedOptions.ssrEntry],
+          import: [(normalizedOptions.ssr as { entry: string }).entry],
         },
       },
       output: {

--- a/packages/angular-rspack/src/lib/models/angular-rspack-plugin-options.ts
+++ b/packages/angular-rspack/src/lib/models/angular-rspack-plugin-options.ts
@@ -19,7 +19,12 @@ export interface AngularRspackPluginOptions {
   index: string;
   browser: string;
   server?: string;
-  ssrEntry?: string;
+  ssr?:
+    | boolean
+    | {
+        entry: string;
+        experimentalPlatform?: 'node' | 'neutral';
+      };
   polyfills: string[];
   assets: string[];
   styles: string[];

--- a/packages/angular-rspack/src/lib/plugins/ng-rspack.ts
+++ b/packages/angular-rspack/src/lib/plugins/ng-rspack.ts
@@ -53,7 +53,11 @@ export class NgRspackPlugin implements RspackPluginInstance {
         scriptLoading: 'module',
         template: join(this.pluginOptions.root, this.pluginOptions.index),
       }).apply(compiler);
-      if (this.pluginOptions.ssrEntry !== undefined) {
+      if (
+        this.pluginOptions.ssr &&
+        typeof this.pluginOptions.ssr === 'object' &&
+        this.pluginOptions.ssr.entry !== undefined
+      ) {
         new AngularSsrDevServer().apply(compiler);
       }
     }


### PR DESCRIPTION
## Current Behaviour

SSR Entry point is currently provided via `ssrEntry` property.

## Expected Behaviour
Angular CLI uses a boolean and object union type for `ssr`. Refactor to use that instead to align.
