### PR TITLE
feat(angular-rspack,angular-rsbuild): add optimization option

### DIFF
--- a/packages/angular-rsbuild/src/lib/config/create-config.ts
+++ b/packages/angular-rsbuild/src/lib/config/create-config.ts
@@ -82,7 +82,13 @@ export function _createConfig(
       tsconfigPath: normalizedOptions.tsConfig,
     },
     plugins: [pluginHoistedJsTransformer(normalizedOptions), ...stylePlugins],
-    mode: isProd ? 'production' : 'development',
+    mode:
+      // mode is set to production to enable optimizations
+      normalizedOptions.optimization === false
+        ? 'development'
+        : isProd
+        ? 'production'
+        : 'development',
     dev: {
       ...(isRunningDevServer && normalizedOptions.hasServer
         ? {

--- a/packages/angular-rsbuild/src/lib/models/normalize-options.ts
+++ b/packages/angular-rsbuild/src/lib/models/normalize-options.ts
@@ -33,6 +33,18 @@ export function getHasServer({
   );
 }
 
+export function validateOptimization(
+  optimization: PluginAngularOptions['optimization']
+) {
+  if (typeof optimization === 'boolean' || optimization === undefined) {
+    return;
+  }
+  if (typeof optimization === 'object')
+    console.warn(
+      'The "optimization" option currently only supports a boolean value. Please check the documentation.'
+    );
+}
+
 export const DEFAULT_PLUGIN_ANGULAR_OPTIONS: PluginAngularOptions = {
   root: process.cwd(),
   index: './src/index.html',
@@ -48,6 +60,7 @@ export const DEFAULT_PLUGIN_ANGULAR_OPTIONS: PluginAngularOptions = {
   aot: true,
   inlineStyleLanguage: 'css',
   tsConfig: join(process.cwd(), 'tsconfig.app.json'),
+  optimization: true,
   useTsProjectReferences: false,
   skipTypeChecking: false,
   devServer: {
@@ -63,8 +76,12 @@ export function normalizeOptions(
     fileReplacements = [],
     server,
     ssrEntry,
+    optimization,
     ...restOptions
   } = options;
+
+  validateOptimization(optimization);
+  const normalizedOptimization = optimization !== false; // @TODO: Add support for optimization options
 
   return {
     ...DEFAULT_PLUGIN_ANGULAR_OPTIONS,
@@ -72,6 +89,7 @@ export function normalizeOptions(
     ...(root != null ? { root } : {}),
     ...(server != null ? { server } : {}),
     ...(ssrEntry != null ? { ssrEntry } : {}),
+    optimization: normalizedOptimization,
     fileReplacements: resolveFileReplacements(fileReplacements, root),
     hasServer: getHasServer({ server, ssrEntry, root }),
   };

--- a/packages/angular-rsbuild/src/lib/models/plugin-options.ts
+++ b/packages/angular-rsbuild/src/lib/models/plugin-options.ts
@@ -8,6 +8,12 @@ export interface DevServerOptions {
   port: number;
 }
 
+export interface OptimizationOptions {
+  scripts?: boolean;
+  styles?: boolean;
+  fonts?: boolean;
+}
+
 export interface PluginAngularOptions {
   root: string;
   index: string;
@@ -22,6 +28,7 @@ export interface PluginAngularOptions {
   aot: boolean;
   inlineStyleLanguage: InlineStyleLanguage;
   tsConfig: string;
+  optimization?: boolean | OptimizationOptions;
   hasServer: boolean;
   skipTypeChecking: boolean;
   useTsProjectReferences?: boolean;

--- a/packages/angular-rspack/src/lib/config/create-config.ts
+++ b/packages/angular-rspack/src/lib/config/create-config.ts
@@ -138,7 +138,7 @@ export function _createConfig(
           writeToDisk: (file) => !file.includes('.hot-update.'),
         },
       },
-      optimization: isProduction
+      optimization: normalizedOptions.optimization
         ? {
             minimize: true,
             runtimeChunk: false,
@@ -254,7 +254,7 @@ export function _createConfig(
       scriptType: 'module',
       module: true,
     },
-    optimization: isProduction
+    optimization: normalizedOptions.optimization
       ? {
           minimize: true,
           runtimeChunk: 'single',

--- a/packages/angular-rspack/src/lib/config/create-config.unit.test.ts
+++ b/packages/angular-rspack/src/lib/config/create-config.unit.test.ts
@@ -74,6 +74,33 @@ describe('createConfig', () => {
             {
               pluginOptions: {
                 ...configBase,
+                optimization: true,
+                useTsProjectReferences: false,
+                polyfills: ['zone.js'],
+                devServer: {
+                  port: 4200,
+                },
+              },
+            },
+          ],
+        }),
+      ]);
+    });
+
+    it('should allow turning off optimizations', () => {
+      expect(
+        createConfig({ options: { ...configBase, optimization: false } })
+      ).toStrictEqual([
+        expect.objectContaining({
+          mode: 'development',
+          devServer: expect.objectContaining({
+            port: 4200,
+          }),
+          plugins: [
+            {
+              pluginOptions: {
+                ...configBase,
+                optimization: false,
                 useTsProjectReferences: false,
                 polyfills: ['zone.js'],
                 devServer: {

--- a/packages/angular-rspack/src/lib/models/angular-rspack-plugin-options.ts
+++ b/packages/angular-rspack/src/lib/models/angular-rspack-plugin-options.ts
@@ -8,6 +8,12 @@ export interface DevServerOptions {
   port: number;
 }
 
+export interface OptimizationOptions {
+  scripts?: boolean;
+  styles?: boolean;
+  fonts?: boolean;
+}
+
 export interface AngularRspackPluginOptions {
   root: string;
   index: string;
@@ -25,6 +31,7 @@ export interface AngularRspackPluginOptions {
   hasServer: boolean;
   skipTypeChecking: boolean;
   useTsProjectReferences?: boolean;
+  optimization?: boolean | OptimizationOptions;
   stylePreprocessorOptions?: StylePreprocessorOptions;
   devServer?: DevServerOptions;
 }

--- a/packages/angular-rspack/src/lib/models/normalize-options.ts
+++ b/packages/angular-rspack/src/lib/models/normalize-options.ts
@@ -33,6 +33,18 @@ export function getHasServer({
   );
 }
 
+export function validateOptimization(
+  optimization: AngularRspackPluginOptions['optimization']
+) {
+  if (typeof optimization === 'boolean' || optimization === undefined) {
+    return;
+  }
+  if (typeof optimization === 'object')
+    console.warn(
+      'The "optimization" option currently only supports a boolean value. Please check the documentation.'
+    );
+}
+
 export function normalizeOptions(
   options: Partial<AngularRspackPluginOptions> = {}
 ): AngularRspackPluginOptions {
@@ -41,7 +53,11 @@ export function normalizeOptions(
     fileReplacements = [],
     server,
     ssrEntry,
+    optimization,
   } = options;
+
+  validateOptimization(optimization);
+  const normalizedOptimization = optimization !== false; // @TODO: Add support for optimization options
 
   return {
     root,
@@ -49,6 +65,7 @@ export function normalizeOptions(
     browser: options.browser ?? './src/main.ts',
     ...(server ? { server } : {}),
     ...(ssrEntry ? { ssrEntry } : {}),
+    optimization: normalizedOptimization,
     polyfills: options.polyfills ?? [],
     assets: options.assets ?? ['./public'],
     styles: options.styles ?? ['./src/styles.css'],


### PR DESCRIPTION
## Current Behaviour
There is currently no method other than setting `NODE_ENV` to turn optimizations off.

## Expected Behaviour
Add an `optimization` property to allow configuring optimizations.
