### PR TITLE
feat(angular-rspack,angular-rsbuild): add outputHashing option

### DIFF
--- a/e2e/fixtures/rspack-csr-css/rspack.config.js
+++ b/e2e/fixtures/rspack-csr-css/rspack.config.js
@@ -12,6 +12,7 @@ module.exports = () => {
         polyfills: ['zone.js'],
         main: './src/main.ts',
         outputPath: './dist/browser',
+        outputHashing: 'none',
         tsConfig: join(__dirname, './tsconfig.app.json'),
         skipTypeChecking: false,
         devServer: {

--- a/packages/angular-rsbuild/src/lib/config/__snapshots__/create-config.csr.ts
+++ b/packages/angular-rsbuild/src/lib/config/__snapshots__/create-config.csr.ts
@@ -54,6 +54,10 @@ const config: RsbuildConfig = {
       },
       "output": {
         "target": "web",
+        "filename": {
+          "js": "[name].[contenthash:8].js",
+          "css": "[name].[contenthash:8].css"
+        },
         "distPath": {
           "root": "dist/browser"
         },

--- a/packages/angular-rsbuild/src/lib/config/__snapshots__/create-config.ssr.ts
+++ b/packages/angular-rsbuild/src/lib/config/__snapshots__/create-config.ssr.ts
@@ -54,6 +54,10 @@ const config: RsbuildConfig = {
       },
       "output": {
         "target": "web",
+        "filename": {
+          "js": "[name].[contenthash:8].js",
+          "css": "[name].[contenthash:8].css"
+        },
         "distPath": {
           "root": "dist/browser"
         },

--- a/packages/angular-rsbuild/src/lib/config/create-config.ts
+++ b/packages/angular-rsbuild/src/lib/config/create-config.ts
@@ -11,12 +11,14 @@ import { pluginAngular } from '../plugin/plugin-angular';
 import { pluginHoistedJsTransformer } from '../plugin/plugin-hoisted-js-transformer';
 import { pluginSass } from '@rsbuild/plugin-sass';
 import { pluginLess } from '@rsbuild/plugin-less';
+import { getOutputHashFormat } from './helpers';
 
 export function _createConfig(
   pluginOptions: Partial<PluginAngularOptions>,
   rsbuildConfigOverrides?: Partial<RsbuildConfig>
 ): RsbuildConfig {
   const normalizedOptions = normalizeOptions(pluginOptions);
+  const hashFormat = getOutputHashFormat(normalizedOptions.outputHashing);
   const browserPolyfills = [...normalizedOptions.polyfills, 'zone.js'];
   const serverPolyfills = [
     ...normalizedOptions.polyfills,
@@ -132,6 +134,10 @@ export function _createConfig(
         },
         output: {
           target: 'web',
+          filename: {
+            js: `[name]${hashFormat.chunk}.js`,
+            css: `[name]${hashFormat.file}.css`,
+          },
           distPath: {
             root: 'dist/browser',
           },

--- a/packages/angular-rsbuild/src/lib/config/helpers.ts
+++ b/packages/angular-rsbuild/src/lib/config/helpers.ts
@@ -1,0 +1,40 @@
+import { OutputHashing, HashFormat } from '../models/plugin-options';
+
+export function getOutputHashFormat(
+  outputHashing: OutputHashing = 'none',
+  length = 8
+): HashFormat {
+  const hashTemplate = `.[contenthash:${length}]`;
+
+  switch (outputHashing) {
+    case 'media':
+      return {
+        chunk: '',
+        extract: '',
+        file: hashTemplate,
+        script: '',
+      };
+    case 'bundles':
+      return {
+        chunk: hashTemplate,
+        extract: hashTemplate,
+        file: '',
+        script: hashTemplate,
+      };
+    case 'all':
+      return {
+        chunk: hashTemplate,
+        extract: hashTemplate,
+        file: hashTemplate,
+        script: hashTemplate,
+      };
+    case 'none':
+    default:
+      return {
+        chunk: '',
+        extract: '',
+        file: '',
+        script: '',
+      };
+  }
+}

--- a/packages/angular-rsbuild/src/lib/models/normalize-options.ts
+++ b/packages/angular-rsbuild/src/lib/models/normalize-options.ts
@@ -61,6 +61,7 @@ export const DEFAULT_PLUGIN_ANGULAR_OPTIONS: PluginAngularOptions = {
   inlineStyleLanguage: 'css',
   tsConfig: join(process.cwd(), 'tsconfig.app.json'),
   optimization: true,
+  outputHashing: 'all',
   useTsProjectReferences: false,
   skipTypeChecking: false,
   devServer: {

--- a/packages/angular-rsbuild/src/lib/models/plugin-options.ts
+++ b/packages/angular-rsbuild/src/lib/models/plugin-options.ts
@@ -14,6 +14,14 @@ export interface OptimizationOptions {
   fonts?: boolean;
 }
 
+export type OutputHashing = 'none' | 'all' | 'media' | 'bundles';
+export type HashFormat = {
+  chunk: string;
+  extract: string;
+  file: string;
+  script: string;
+};
+
 export interface PluginAngularOptions {
   root: string;
   index: string;
@@ -29,6 +37,7 @@ export interface PluginAngularOptions {
   inlineStyleLanguage: InlineStyleLanguage;
   tsConfig: string;
   optimization?: boolean | OptimizationOptions;
+  outputHashing?: OutputHashing;
   hasServer: boolean;
   skipTypeChecking: boolean;
   useTsProjectReferences?: boolean;

--- a/packages/angular-rspack/src/lib/config/create-config.ts
+++ b/packages/angular-rspack/src/lib/config/create-config.ts
@@ -12,6 +12,7 @@ import {
   TS_ALL_EXT_REGEX,
 } from '@nx/angular-rspack-compiler';
 import { getStyleLoaders } from './style-config-utils';
+import { getOutputHashFormat } from './helpers';
 
 export function _createConfig(
   options: AngularRspackPluginOptions,
@@ -19,6 +20,7 @@ export function _createConfig(
 ): Configuration[] {
   const normalizedOptions = normalizeOptions(options);
   const isProduction = process.env['NODE_ENV'] === 'production';
+  const hashFormat = getOutputHashFormat(normalizedOptions.outputHashing);
 
   const defaultConfig = {
     context: normalizedOptions.root,
@@ -248,9 +250,9 @@ export function _createConfig(
       publicPath: 'auto',
       clean: true,
       path: join(normalizedOptions.root, 'dist/browser'),
-      cssFilename: isProduction ? '[name].[contenthash].css' : '[name].css',
-      filename: isProduction ? '[name].[contenthash].js' : '[name].js',
-      chunkFilename: isProduction ? '[name].[contenthash].js' : '[name].js',
+      cssFilename: `[name]${hashFormat.file}.css`,
+      filename: `[name]${hashFormat.chunk}.js`,
+      chunkFilename: `[name]${hashFormat.chunk}.js`,
       scriptType: 'module',
       module: true,
     },

--- a/packages/angular-rspack/src/lib/config/create-config.unit.test.ts
+++ b/packages/angular-rspack/src/lib/config/create-config.unit.test.ts
@@ -13,6 +13,8 @@ describe('createConfig', () => {
     styles: [],
     assets: [],
     fileReplacements: [],
+    optimization: true,
+    outputHashing: 'all',
     scripts: [],
     aot: true,
     hasServer: false,

--- a/packages/angular-rspack/src/lib/config/helpers.ts
+++ b/packages/angular-rspack/src/lib/config/helpers.ts
@@ -1,0 +1,40 @@
+import { OutputHashing, HashFormat } from '../models';
+
+export function getOutputHashFormat(
+  outputHashing: OutputHashing = 'none',
+  length = 8
+): HashFormat {
+  const hashTemplate = `.[contenthash:${length}]`;
+
+  switch (outputHashing) {
+    case 'media':
+      return {
+        chunk: '',
+        extract: '',
+        file: hashTemplate,
+        script: '',
+      };
+    case 'bundles':
+      return {
+        chunk: hashTemplate,
+        extract: hashTemplate,
+        file: '',
+        script: hashTemplate,
+      };
+    case 'all':
+      return {
+        chunk: hashTemplate,
+        extract: hashTemplate,
+        file: hashTemplate,
+        script: hashTemplate,
+      };
+    case 'none':
+    default:
+      return {
+        chunk: '',
+        extract: '',
+        file: '',
+        script: '',
+      };
+  }
+}

--- a/packages/angular-rspack/src/lib/models/angular-rspack-plugin-options.ts
+++ b/packages/angular-rspack/src/lib/models/angular-rspack-plugin-options.ts
@@ -14,6 +14,14 @@ export interface OptimizationOptions {
   fonts?: boolean;
 }
 
+export type OutputHashing = 'none' | 'all' | 'media' | 'bundles';
+export type HashFormat = {
+  chunk: string;
+  extract: string;
+  file: string;
+  script: string;
+};
+
 export interface AngularRspackPluginOptions {
   root: string;
   index: string;
@@ -32,6 +40,7 @@ export interface AngularRspackPluginOptions {
   skipTypeChecking: boolean;
   useTsProjectReferences?: boolean;
   optimization?: boolean | OptimizationOptions;
+  outputHashing?: OutputHashing;
   stylePreprocessorOptions?: StylePreprocessorOptions;
   devServer?: DevServerOptions;
 }

--- a/packages/angular-rspack/src/lib/models/normalize-options.ts
+++ b/packages/angular-rspack/src/lib/models/normalize-options.ts
@@ -72,6 +72,7 @@ export function normalizeOptions(
     scripts: options.scripts ?? [],
     fileReplacements: resolveFileReplacements(fileReplacements, root),
     aot: options.aot ?? true,
+    outputHashing: options.outputHashing ?? 'all',
     inlineStyleLanguage: options.inlineStyleLanguage ?? 'css',
     tsConfig: options.tsConfig ?? join(root, 'tsconfig.app.json'),
     hasServer: getHasServer({ server, ssrEntry, root }),


### PR DESCRIPTION
## Current Behaviour

There is no option to control hashing of outputs created by rspack

## Expected Behaviour

Add `outputHashing` option aligned with Angular CLI to provide option to configure hashing
