### PR TITLE
feat(angular-rspack,angular-rsbuild): remove root from api

### DIFF
--- a/e2e/fixtures/rspack-csr-css/rspack.config.js
+++ b/e2e/fixtures/rspack-csr-css/rspack.config.js
@@ -4,7 +4,6 @@ module.exports = () => {
     const { createConfig } = require('@nx/angular-rspack');
     return createConfig({
       options: {
-        root: __dirname,
         name: 'rspack-csr-css',
         index: './src/index.html',
         assets: ['./public'],

--- a/packages/angular-rsbuild/src/lib/config/create-config.integration.test.ts
+++ b/packages/angular-rsbuild/src/lib/config/create-config.integration.test.ts
@@ -5,7 +5,6 @@ import * as normalizeModule from '../models/normalize-options.ts';
 import { DEFAULT_PLUGIN_ANGULAR_OPTIONS } from '../models/normalize-options.ts';
 
 describe('createConfig', () => {
-  const root = process.cwd();
   const argvSpy = vi.spyOn(process, 'argv', 'get');
   const normalizeOptionsSpy = vi.spyOn(normalizeModule, 'normalizeOptions');
 
@@ -21,7 +20,6 @@ describe('createConfig', () => {
   it('should create a CSR config', async () => {
     const config = await createConfig({
       options: {
-        root,
         inlineStyleLanguage: 'scss',
         tsConfig: './tsconfig.app.json',
         aot: true,
@@ -47,9 +45,8 @@ describe('createConfig', () => {
   it('should create a SSR config', async () => {
     const config = await createConfig({
       options: {
-        root,
         server: './src/main.server.ts',
-        ssrEntry: './src/server.ts',
+        ssr: { entry: './src/server.ts' },
         inlineStyleLanguage: 'scss',
         tsConfig: './tsconfig.app.json',
       },

--- a/packages/angular-rsbuild/src/lib/config/create-config.ts
+++ b/packages/angular-rsbuild/src/lib/config/create-config.ts
@@ -79,8 +79,9 @@ export async function _createConfig(
     }
   }
 
+  const root = process.cwd();
   const rsbuildPluginAngularConfig = defineConfig({
-    root: normalizedOptions.root,
+    root,
     source: {
       tsconfigPath: normalizedOptions.tsConfig,
     },
@@ -117,18 +118,12 @@ export async function _createConfig(
         normalizedOptions.devServer?.sslKey &&
         normalizedOptions.devServer?.sslCert
           ? {
-              key: resolve(
-                normalizedOptions.root,
-                normalizedOptions.devServer.sslKey
-              ),
-              cert: resolve(
-                normalizedOptions.root,
-                normalizedOptions.devServer.sslCert
-              ),
+              key: resolve(root, normalizedOptions.devServer.sslKey),
+              cert: resolve(root, normalizedOptions.devServer.sslCert),
             }
           : undefined,
       proxy: await getProxyConfig(
-        normalizedOptions.root,
+        root,
         normalizedOptions.devServer?.proxyConfig
       ),
     },

--- a/packages/angular-rsbuild/src/lib/config/create-config.unit.test.ts
+++ b/packages/angular-rsbuild/src/lib/config/create-config.unit.test.ts
@@ -99,7 +99,6 @@ describe('createConfig', () => {
     await expect(
       createConfig({
         options: {
-          root: 'plugin-options',
           polyfills: [],
           styles: [],
           assets: [],
@@ -112,10 +111,6 @@ describe('createConfig', () => {
       })
     ).resolves.not.toThrow();
     expect(defineConfigSpy).toHaveBeenCalledTimes(2);
-    expect(defineConfigSpy).toHaveBeenNthCalledWith(
-      1,
-      expect.objectContaining({ root: 'plugin-options' })
-    );
     expect(defineConfigSpy).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
@@ -135,7 +130,6 @@ describe('createConfig', () => {
     await expect(
       createConfig({
         options: {
-          root: 'plugin-options',
           polyfills: [],
           styles: [],
           assets: [],
@@ -148,7 +142,6 @@ describe('createConfig', () => {
     expect(defineConfigSpy).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
-        root: 'plugin-options',
         server: expect.objectContaining({ port: 8080 }),
       })
     );

--- a/packages/angular-rsbuild/src/lib/models/normalize-options.ts
+++ b/packages/angular-rsbuild/src/lib/models/normalize-options.ts
@@ -27,8 +27,8 @@ export function resolveFileReplacements(
 export function getHasServer({
   server,
   ssr,
-  root,
-}: Pick<PluginAngularOptions, 'server' | 'ssr' | 'root'>): boolean {
+}: Pick<PluginAngularOptions, 'server' | 'ssr'>): boolean {
+  const root = process.cwd();
   return !!(
     server &&
     ssr &&
@@ -72,7 +72,6 @@ export function validateOptimization(
 }
 
 export const DEFAULT_PLUGIN_ANGULAR_OPTIONS: PluginAngularOptions = {
-  root: process.cwd(),
   index: './src/index.html',
   browser: './src/main.ts',
   server: undefined,
@@ -98,8 +97,8 @@ export const DEFAULT_PLUGIN_ANGULAR_OPTIONS: PluginAngularOptions = {
 export function normalizeOptions(
   options: Partial<PluginAngularOptions> = {}
 ): NormalizedPluginAngularOptions {
+  const root = process.cwd();
   const {
-    root = DEFAULT_PLUGIN_ANGULAR_OPTIONS.root,
     fileReplacements = [],
     server,
     ssr,
@@ -127,7 +126,6 @@ export function normalizeOptions(
   return {
     ...DEFAULT_PLUGIN_ANGULAR_OPTIONS,
     ...restOptions,
-    ...(root != null ? { root } : {}),
     ...(server != null ? { server } : {}),
     ...(ssr != null ? { ssr: normalizedSsr } : {}),
     optimization: normalizedOptimization,
@@ -135,7 +133,7 @@ export function normalizeOptions(
     aot,
     outputHashing: options.outputHashing ?? 'all',
     fileReplacements: resolveFileReplacements(fileReplacements, root),
-    hasServer: getHasServer({ server, ssr: normalizedSsr, root }),
+    hasServer: getHasServer({ server, ssr: normalizedSsr }),
     devServer: normalizeDevServer(devServer),
   };
 }

--- a/packages/angular-rsbuild/src/lib/models/normalize-options.unit.test.ts
+++ b/packages/angular-rsbuild/src/lib/models/normalize-options.unit.test.ts
@@ -54,13 +54,13 @@ describe('getHasServer', () => {
       },
       MEMFS_VOLUME
     );
+    vi.stubGlobal('process', { cwd: () => MEMFS_VOLUME });
   });
 
   it('should return true if both server and ssr.entry files exist', () => {
     const result = getHasServer({
       server: 'server.js',
       ssr: { entry: 'ssr-entry.js' },
-      root: MEMFS_VOLUME,
     });
 
     expect(result).toBe(true);
@@ -69,7 +69,6 @@ describe('getHasServer', () => {
   it('should return false if server file is not provides', () => {
     const result = getHasServer({
       ssr: { entry: 'ssr-entry.js' },
-      root: '/project-root',
     });
 
     expect(result).toBe(false);
@@ -78,16 +77,13 @@ describe('getHasServer', () => {
   it('should return false if ssr.entry file is not provides', () => {
     const result = getHasServer({
       server: 'server.js',
-      root: '/project-root',
     });
 
     expect(result).toBe(false);
   });
 
   it('should return false if neither file are not provides', () => {
-    const result = getHasServer({
-      root: '/project-root',
-    });
+    const result = getHasServer({});
 
     expect(result).toBe(false);
   });
@@ -96,7 +92,6 @@ describe('getHasServer', () => {
     const result = getHasServer({
       server: 'non-existing-server.js',
       ssr: { entry: 'ssr-entry.js' },
-      root: '/project-root',
     });
 
     expect(result).toBe(false);
@@ -106,7 +101,6 @@ describe('getHasServer', () => {
     const result = getHasServer({
       server: 'server.js',
       ssr: { entry: 'non-existing-ssr-entry.js' },
-      root: '/project-root',
     });
 
     expect(result).toBe(false);
@@ -116,7 +110,6 @@ describe('getHasServer', () => {
     const result = getHasServer({
       server: 'non-existing-server.js',
       ssr: { entry: 'non-existing-ssr-entry.js' },
-      root: '/project-root',
     });
 
     expect(result).toBe(false);
@@ -144,13 +137,13 @@ describe('normalizeOptions', () => {
     });
   });
 
-  it('should apply provides options', () => {
-    const result = normalizeOptions({ root: 'project-root' });
+  it('should set optimization to false when provided in options', () => {
+    const result = normalizeOptions({ optimization: false });
 
     expect(result).toStrictEqual({
       ...defaultOptions,
-      advancedOptimizations: true,
-      root: 'project-root',
+      optimization: false,
+      advancedOptimizations: false,
     });
   });
 
@@ -173,7 +166,6 @@ describe('normalizeOptions', () => {
       normalizeOptions({
         server: 'server.js',
         ssr: { entry: 'ssr-entry.js' },
-        root: MEMFS_VOLUME,
       }).hasServer
     ).toStrictEqual(true);
   });
@@ -185,7 +177,6 @@ describe('normalizeOptions', () => {
 
     const resolvedFileReplacements = normalizeOptions({
       fileReplacements,
-      root: MEMFS_VOLUME,
     }).fileReplacements;
 
     expect(resolvedFileReplacements).toStrictEqual([

--- a/packages/angular-rsbuild/src/lib/models/plugin-options.ts
+++ b/packages/angular-rsbuild/src/lib/models/plugin-options.ts
@@ -27,7 +27,6 @@ export type HashFormat = {
 };
 
 export interface PluginAngularOptions {
-  root: string;
   index: string;
   browser: string;
   server?: string;

--- a/packages/angular-rsbuild/src/lib/plugin/plugin-hoisted-js-transformer.ts
+++ b/packages/angular-rsbuild/src/lib/plugin/plugin-hoisted-js-transformer.ts
@@ -18,6 +18,7 @@ export const pluginHoistedJsTransformer = (
   post: ['plugin-angular'],
   setup(api) {
     const pluginOptions = normalizeOptions(options);
+    const root = api.context.rootPath ?? process.cwd();
     const config = api.getRsbuildConfig();
     const typescriptFileCache = new Map<string, string | Uint8Array>();
     let watchMode = false;
@@ -48,7 +49,7 @@ export const pluginHoistedJsTransformer = (
     api.onBeforeEnvironmentCompile(async () => {
       const parallelCompilation = await setupCompilationWithParallelCompilation(
         config,
-        pluginOptions
+        { ...pluginOptions, root }
       );
       await buildAndAnalyzeWithParallelCompilation(
         parallelCompilation,

--- a/packages/angular-rspack/src/lib/config/create-config.ts
+++ b/packages/angular-rspack/src/lib/config/create-config.ts
@@ -22,9 +22,10 @@ export async function _createConfig(
   const normalizedOptions = normalizeOptions(options);
   const isProduction = process.env['NODE_ENV'] === 'production';
   const hashFormat = getOutputHashFormat(normalizedOptions.outputHashing);
+  const root = process.cwd();
 
   const defaultConfig: Configuration = {
-    context: normalizedOptions.root,
+    context: root,
     mode: isProduction ? 'production' : 'development',
     output: {
       uniqueName: 'rspack-angular',
@@ -108,7 +109,7 @@ export async function _createConfig(
         ...defaultConfig.output,
         publicPath: 'auto',
         clean: true,
-        path: join(normalizedOptions.root, 'dist', 'server'),
+        path: join(root, 'dist', 'server'),
         filename: '[name].js',
         chunkFilename: '[name].js',
       },
@@ -145,20 +146,14 @@ export async function _createConfig(
             normalizedOptions.devServer?.sslKey &&
             normalizedOptions.devServer?.sslCert
               ? {
-                  key: resolve(
-                    normalizedOptions.root,
-                    normalizedOptions.devServer.sslKey
-                  ),
-                  cert: resolve(
-                    normalizedOptions.root,
-                    normalizedOptions.devServer.sslCert
-                  ),
+                  key: resolve(root, normalizedOptions.devServer.sslKey),
+                  cert: resolve(root, normalizedOptions.devServer.sslCert),
                 }
               : {},
           type: normalizedOptions.devServer?.ssl ? 'https' : 'http',
         },
         proxy: await getProxyConfig(
-          normalizedOptions.root,
+          root,
           normalizedOptions.devServer?.proxyConfig
         ),
       },
@@ -260,20 +255,14 @@ export async function _createConfig(
           normalizedOptions.devServer?.sslKey &&
           normalizedOptions.devServer?.sslCert
             ? {
-                key: resolve(
-                  normalizedOptions.root,
-                  normalizedOptions.devServer.sslKey
-                ),
-                cert: resolve(
-                  normalizedOptions.root,
-                  normalizedOptions.devServer.sslCert
-                ),
+                key: resolve(root, normalizedOptions.devServer.sslKey),
+                cert: resolve(root, normalizedOptions.devServer.sslCert),
               }
             : {},
         type: normalizedOptions.devServer?.ssl ? 'https' : 'http',
       },
       proxy: await getProxyConfig(
-        normalizedOptions.root,
+        root,
         normalizedOptions.devServer?.proxyConfig
       ),
       onListening: (devServer) => {
@@ -292,7 +281,7 @@ export async function _createConfig(
       hashFunction: isProduction ? 'xxhash64' : undefined,
       publicPath: 'auto',
       clean: true,
-      path: join(normalizedOptions.root, 'dist/browser'),
+      path: join(root, 'dist/browser'),
       cssFilename: `[name]${hashFormat.file}.css`,
       filename: `[name]${hashFormat.chunk}.js`,
       chunkFilename: `[name]${hashFormat.chunk}.js`,

--- a/packages/angular-rspack/src/lib/config/create-config.unit.test.ts
+++ b/packages/angular-rspack/src/lib/config/create-config.unit.test.ts
@@ -4,7 +4,6 @@ import { AngularRspackPluginOptions } from '../models';
 
 describe('createConfig', () => {
   const configBase: AngularRspackPluginOptions = {
-    root: '',
     browser: './src/main.ts',
     index: './src/index.html',
     tsConfig: './tsconfig.base.json',

--- a/packages/angular-rspack/src/lib/models/angular-rspack-plugin-options.ts
+++ b/packages/angular-rspack/src/lib/models/angular-rspack-plugin-options.ts
@@ -27,7 +27,6 @@ export type HashFormat = {
 };
 
 export interface AngularRspackPluginOptions {
-  root: string;
   index: string;
   browser: string;
   server?: string;

--- a/packages/angular-rspack/src/lib/models/normalize-options.ts
+++ b/packages/angular-rspack/src/lib/models/normalize-options.ts
@@ -27,8 +27,8 @@ export function resolveFileReplacements(
 export function getHasServer({
   server,
   ssr,
-  root,
-}: Pick<AngularRspackPluginOptions, 'server' | 'ssr' | 'root'>): boolean {
+}: Pick<AngularRspackPluginOptions, 'server' | 'ssr'>): boolean {
+  const root = process.cwd();
   return !!(
     server &&
     ssr &&
@@ -74,13 +74,7 @@ export function validateOptimization(
 export function normalizeOptions(
   options: Partial<AngularRspackPluginOptions> = {}
 ): NormalizedAngularRspackPluginOptions {
-  const {
-    root = process.cwd(),
-    fileReplacements = [],
-    server,
-    ssr,
-    optimization,
-  } = options;
+  const { fileReplacements = [], server, ssr, optimization } = options;
 
   validateSsr(ssr);
 
@@ -96,12 +90,13 @@ export function normalizeOptions(
   validateOptimization(optimization);
   const normalizedOptimization = optimization !== false; // @TODO: Add support for optimization options
 
+  const root = process.cwd();
+
   const aot = options.aot ?? true;
   // @TODO: should be `aot && normalizedOptimization.scripts` once we support optimization options
   const advancedOptimizations = aot && normalizedOptimization;
 
   return {
-    root,
     index: options.index ?? './src/index.html',
     browser: options.browser ?? './src/main.ts',
     ...(server ? { server } : {}),
@@ -117,7 +112,7 @@ export function normalizeOptions(
     outputHashing: options.outputHashing ?? 'all',
     inlineStyleLanguage: options.inlineStyleLanguage ?? 'css',
     tsConfig: options.tsConfig ?? join(root, 'tsconfig.app.json'),
-    hasServer: getHasServer({ server, ssr: normalizedSsr, root }),
+    hasServer: getHasServer({ server, ssr: normalizedSsr }),
     skipTypeChecking: options.skipTypeChecking ?? false,
     useTsProjectReferences: options.useTsProjectReferences ?? false,
     devServer: normalizeDevServer(options.devServer),

--- a/packages/angular-rspack/src/lib/plugins/ng-rspack.ts
+++ b/packages/angular-rspack/src/lib/plugins/ng-rspack.ts
@@ -21,6 +21,7 @@ export class NgRspackPlugin implements RspackPluginInstance {
   }
 
   apply(compiler: Compiler) {
+    const root = compiler.options.context ?? process.cwd();
     const isProduction = process.env['NODE_ENV'] === 'production';
     const isDevServer = process.env['WEBPACK_SERVE'];
 
@@ -51,7 +52,7 @@ export class NgRspackPlugin implements RspackPluginInstance {
         minify: false,
         inject: 'body',
         scriptLoading: 'module',
-        template: join(this.pluginOptions.root, this.pluginOptions.index),
+        template: join(root, this.pluginOptions.index),
       }).apply(compiler);
       if (
         this.pluginOptions.ssr &&
@@ -72,7 +73,7 @@ export class NgRspackPlugin implements RspackPluginInstance {
     if (this.pluginOptions.assets) {
       new CopyRspackPlugin({
         patterns: (this.pluginOptions.assets ?? []).map((assetPath) => ({
-          from: join(this.pluginOptions.root, assetPath),
+          from: join(root, assetPath),
           to: '.',
           noErrorOnMissing: true,
         })),


### PR DESCRIPTION
## Current Behaviour

The `root` option is not required and can be inferred

## Expected Behaviour

Remove the `root` option and infer it based on cwd of process
