### PR TITLE
feat(angular-rspack,angular-rsbuild): support `ssl`, `sslKey`, `sslCert`, and `proxyConfig` options

### DIFF
--- a/e2e/fixtures/rspack-csr-css/package.json
+++ b/e2e/fixtures/rspack-csr-css/package.json
@@ -5,5 +5,15 @@
   "scripts": {},
   "dependencies": {
     "@nx/angular-rspack": "workspace:*"
+  },
+  "nx": {
+    "targets": {
+      "serve-api": {
+        "command": "node ./src/api.mjs",
+        "options": {
+          "cwd": "e2e/fixtures/rspack-csr-css"
+        }
+      }
+    }
   }
 }

--- a/e2e/fixtures/rspack-csr-css/proxy.conf.json
+++ b/e2e/fixtures/rspack-csr-css/proxy.conf.json
@@ -1,0 +1,7 @@
+{
+  "/api": {
+    "target": "http://localhost:3000",
+    "secure": false,
+    "changeOrigin": true
+  }
+}

--- a/e2e/fixtures/rspack-csr-css/rspack.config.js
+++ b/e2e/fixtures/rspack-csr-css/rspack.config.js
@@ -17,6 +17,7 @@ module.exports = () => {
         skipTypeChecking: false,
         devServer: {
           port: 8080,
+          proxyConfig: './proxy.conf.json',
         },
       },
     });

--- a/e2e/fixtures/rspack-csr-css/src/api.mjs
+++ b/e2e/fixtures/rspack-csr-css/src/api.mjs
@@ -1,0 +1,15 @@
+import http from 'node:http';
+
+const server = http.createServer((req, res) => {
+  const name = req.url?.split('/api/')[1] || 'stranger';
+
+  res.writeHead(200, {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*',
+  });
+  res.end(JSON.stringify({ message: `Hello ${name}!` }));
+});
+
+server.listen(3000, () => {
+  console.log('Server running at http://localhost:3000');
+});

--- a/e2e/fixtures/rspack-csr-css/src/app/api.service.ts
+++ b/e2e/fixtures/rspack-csr-css/src/app/api.service.ts
@@ -1,0 +1,14 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { map, type Observable } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class ApiService {
+  constructor(private readonly http: HttpClient) {}
+
+  getGreeting(name: string): Observable<string> {
+    return this.http
+      .get<{ message: string }>(`/api/${name}`)
+      .pipe(map((response) => response.message));
+  }
+}

--- a/e2e/fixtures/rspack-csr-css/src/app/app.component.html
+++ b/e2e/fixtures/rspack-csr-css/src/app/app.component.html
@@ -1,3 +1,4 @@
+<p>{{ greeting$ | async }}</p>
 <app-scss-inline-test></app-scss-inline-test>
 <app-nx-welcome></app-nx-welcome>
 <router-outlet></router-outlet>

--- a/e2e/fixtures/rspack-csr-css/src/app/app.component.ts
+++ b/e2e/fixtures/rspack-csr-css/src/app/app.component.ts
@@ -1,14 +1,29 @@
-import { Component } from '@angular/core';
+import { AsyncPipe } from '@angular/common';
+import { Component, type OnInit } from '@angular/core';
 import { RouterModule } from '@angular/router';
+import type { Observable } from 'rxjs';
+import { ApiService } from './api.service';
 import { NxWelcomeComponent } from './nx-welcome.component';
 import { ScssInlineTestComponent } from './scss-inline-test';
 
 @Component({
-  imports: [NxWelcomeComponent, RouterModule, ScssInlineTestComponent],
+  imports: [
+    NxWelcomeComponent,
+    RouterModule,
+    ScssInlineTestComponent,
+    AsyncPipe,
+  ],
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrl: './app.component.css',
 })
-export class AppComponent {
+export class AppComponent implements OnInit {
   title = 'rsbuild-csr-css';
+  greeting$!: Observable<string>;
+
+  constructor(private readonly apiService: ApiService) {}
+
+  ngOnInit() {
+    this.greeting$ = this.apiService.getGreeting('world');
+  }
 }

--- a/e2e/fixtures/rspack-csr-css/src/app/app.config.ts
+++ b/e2e/fixtures/rspack-csr-css/src/app/app.config.ts
@@ -1,3 +1,4 @@
+import { provideHttpClient, withFetch } from '@angular/common/http';
 import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { appRoutes } from './app.routes';
@@ -6,5 +7,6 @@ export const appConfig: ApplicationConfig = {
   providers: [
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(appRoutes),
+    provideHttpClient(withFetch()),
   ],
 };

--- a/e2e/fixtures/rspack-csr-css/tsconfig.editor.json
+++ b/e2e/fixtures/rspack-csr-css/tsconfig.editor.json
@@ -1,6 +1,6 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "src/api.mjs"],
   "compilerOptions": {},
   "exclude": [
     "jest.config.ts",

--- a/packages/angular-rsbuild/package.json
+++ b/packages/angular-rsbuild/package.json
@@ -8,10 +8,11 @@
   "version": "19.0.0-alpha.29",
   "dependencies": {
     "@nx/angular-rspack-compiler": "workspace:*",
-    "sass-embedded": "^1.79.3",
-    "@rsbuild/plugin-sass": "^1.1.2",
     "@rsbuild/plugin-less": "^1.1.1",
+    "@rsbuild/plugin-sass": "^1.1.2",
     "express": "4.21.1",
+    "jsonc-parser": "^3.3.1",
+    "sass-embedded": "^1.79.3",
     "tslib": "^2.3.0"
   },
   "devDependencies": {

--- a/packages/angular-rsbuild/src/lib/config/create-config.integration.test.ts
+++ b/packages/angular-rsbuild/src/lib/config/create-config.integration.test.ts
@@ -18,8 +18,8 @@ describe('createConfig', () => {
     vi.clearAllMocks();
   });
 
-  it('should create a CSR config', () => {
-    const config = createConfig({
+  it('should create a CSR config', async () => {
+    const config = await createConfig({
       options: {
         root,
         inlineStyleLanguage: 'scss',
@@ -44,8 +44,8 @@ describe('createConfig', () => {
     ).toMatchFileSnapshot('__snapshots__/create-config.csr.ts');
   });
 
-  it('should create a SSR config', () => {
-    const config = createConfig({
+  it('should create a SSR config', async () => {
+    const config = await createConfig({
       options: {
         root,
         server: './src/main.server.ts',

--- a/packages/angular-rsbuild/src/lib/config/create-config.unit.test.ts
+++ b/packages/angular-rsbuild/src/lib/config/create-config.unit.test.ts
@@ -25,10 +25,10 @@ describe('createConfig', () => {
 
   it.each(['development', 'not-production'])(
     'should create config for mode "development" if env variable NODE_ENV is "%s"',
-    (nodeEnv) => {
+    async (nodeEnv) => {
       vi.stubEnv('NODE_ENV', nodeEnv);
 
-      expect(() => createConfig({ options: {} })).not.toThrow();
+      await expect(createConfig({ options: {} })).resolves.not.toThrow();
 
       expect(defineConfigSpy).toHaveBeenCalledWith(
         expect.objectContaining({ mode: 'development' })
@@ -36,17 +36,17 @@ describe('createConfig', () => {
     }
   );
 
-  it('should create config for mode "production" if env variable NODE_ENV is "production"', () => {
+  it('should create config for mode "production" if env variable NODE_ENV is "production"', async () => {
     vi.stubEnv('NODE_ENV', 'production');
 
-    expect(() => createConfig({ options: {} })).not.toThrow();
+    await expect(createConfig({ options: {} })).resolves.not.toThrow();
 
     expect(defineConfigSpy).toHaveBeenCalledWith(
       expect.objectContaining({ mode: 'production' })
     );
   });
 
-  it('should have dev property defined if the process started with "dev" argument and a server is configured', () => {
+  it('should have dev property defined if the process started with "dev" argument and a server is configured', async () => {
     argvSpy.mockReturnValue(['irrelevant', 'irrelevant', 'dev']);
     normalizeOptionsSpy.mockReturnValue({
       ...DEFAULT_PLUGIN_ANGULAR_OPTIONS,
@@ -54,7 +54,7 @@ describe('createConfig', () => {
       hasServer: true,
     });
 
-    expect(() => createConfig({ options: {} })).not.toThrow();
+    await expect(createConfig({ options: {} })).resolves.not.toThrow();
 
     expect(defineConfigSpy).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -71,10 +71,10 @@ describe('createConfig', () => {
     );
   });
 
-  it('should create config without dev property configured if not running dev server', () => {
+  it('should create config without dev property configured if not running dev server', async () => {
     argvSpy.mockReturnValue([]);
 
-    expect(() => createConfig({ options: {} })).not.toThrow();
+    await expect(createConfig({ options: {} })).resolves.not.toThrow();
 
     expect(defineConfigSpy).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -83,13 +83,13 @@ describe('createConfig', () => {
     );
   });
 
-  it('should used definedConfig for both passed objects', () => {
+  it('should used definedConfig for both passed objects', async () => {
     defineConfigSpy.mockImplementation((config) => config);
     normalizeOptionsSpy.mockImplementation(
       (options) => options as PluginAngularOptions
     );
 
-    expect(() =>
+    await expect(
       createConfig({
         options: {
           root: 'plugin-options',
@@ -103,7 +103,7 @@ describe('createConfig', () => {
           },
         },
       })
-    ).not.toThrow();
+    ).resolves.not.toThrow();
     expect(defineConfigSpy).toHaveBeenCalledTimes(2);
     expect(defineConfigSpy).toHaveBeenNthCalledWith(
       1,
@@ -119,13 +119,13 @@ describe('createConfig', () => {
     );
   });
 
-  it('should allow changing the devServer port', () => {
+  it('should allow changing the devServer port', async () => {
     defineConfigSpy.mockImplementation((config) => config);
     normalizeOptionsSpy.mockImplementation(
       (options) => options as PluginAngularOptions
     );
 
-    expect(() =>
+    await expect(
       createConfig({
         options: {
           root: 'plugin-options',
@@ -137,7 +137,7 @@ describe('createConfig', () => {
           },
         },
       })
-    ).not.toThrow();
+    ).resolves.not.toThrow();
     expect(defineConfigSpy).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({

--- a/packages/angular-rsbuild/src/lib/config/dev-server-config-utils.ts
+++ b/packages/angular-rsbuild/src/lib/config/dev-server-config-utils.ts
@@ -1,0 +1,140 @@
+import type { ProxyConfig } from '@rsbuild/core';
+import assert from 'node:assert';
+import { existsSync, promises as fsPromises } from 'node:fs';
+import { extname, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export async function getProxyConfig(
+  root: string,
+  proxyConfig: string | undefined
+): Promise<ProxyConfig | undefined> {
+  if (!proxyConfig) {
+    return undefined;
+  }
+
+  const proxyPath = resolve(root, proxyConfig);
+
+  if (!existsSync(proxyPath)) {
+    throw new Error(`Proxy configuration file ${proxyPath} does not exist.`);
+  }
+
+  let proxyConfiguration: Record<string, object> | object[];
+
+  switch (extname(proxyPath)) {
+    case '.json': {
+      const content = await fsPromises.readFile(proxyPath, 'utf-8');
+
+      const { parse, printParseErrorCode } = await import('jsonc-parser');
+      const parseErrors: import('jsonc-parser').ParseError[] = [];
+      proxyConfiguration = parse(content, parseErrors, {
+        allowTrailingComma: true,
+      });
+
+      if (parseErrors.length > 0) {
+        let errorMessage = `Proxy configuration file ${proxyPath} contains parse errors:`;
+        for (const parseError of parseErrors) {
+          const { line, column } = getJsonErrorLineColumn(
+            parseError.offset,
+            content
+          );
+          errorMessage += `\n[${line}, ${column}] ${printParseErrorCode(
+            parseError.error
+          )}`;
+        }
+        throw new Error(errorMessage);
+      }
+
+      break;
+    }
+    case '.mjs':
+      // Load the ESM configuration file using the TypeScript dynamic import workaround.
+      // Once TypeScript provides support for keeping the dynamic import this workaround can be
+      // changed to a direct dynamic import.
+      proxyConfiguration = (
+        await loadEsmModule<{ default: Record<string, object> | object[] }>(
+          pathToFileURL(proxyPath)
+        )
+      ).default;
+      break;
+    case '.cjs':
+      proxyConfiguration = require(proxyPath);
+      break;
+    default:
+      // The file could be either CommonJS or ESM.
+      // CommonJS is tried first then ESM if loading fails.
+      try {
+        proxyConfiguration = require(proxyPath);
+      } catch (e) {
+        assertIsError(e);
+        if (e.code !== 'ERR_REQUIRE_ESM') {
+          throw e;
+        }
+
+        // Load the ESM configuration file using the TypeScript dynamic import workaround.
+        // Once TypeScript provides support for keeping the dynamic import this workaround can be
+        // changed to a direct dynamic import.
+        proxyConfiguration = (
+          await loadEsmModule<{ default: Record<string, object> | object[] }>(
+            pathToFileURL(proxyPath)
+          )
+        ).default;
+      }
+  }
+
+  return normalizeProxyConfiguration(proxyConfiguration);
+}
+
+function getJsonErrorLineColumn(offset: number, content: string) {
+  if (offset === 0) {
+    return { line: 1, column: 1 };
+  }
+
+  let line = 0;
+  let position = 0;
+  while (true) {
+    ++line;
+
+    const nextNewline = content.indexOf('\n', position);
+    if (nextNewline === -1 || nextNewline > offset) {
+      break;
+    }
+
+    position = nextNewline + 1;
+  }
+
+  return { line, column: offset - position + 1 };
+}
+
+function normalizeProxyConfiguration(
+  proxy: Record<string, object> | object[]
+): ProxyConfig {
+  return Array.isArray(proxy)
+    ? proxy
+    : Object.entries(proxy).map(([context, value]) => ({
+        context: [context],
+        ...value,
+      }));
+}
+
+function assertIsError(
+  value: unknown
+): asserts value is Error & { code?: string } {
+  const isError =
+    value instanceof Error ||
+    // The following is needing to identify errors coming from RxJs.
+    (typeof value === 'object' &&
+      value &&
+      'name' in value &&
+      'message' in value);
+  assert(isError, 'catch clause variable is not an Error instance');
+}
+
+let load: (<T>(modulePath: string | URL) => Promise<T>) | undefined;
+function loadEsmModule<T>(modulePath: string | URL): Promise<T> {
+  load ??= new Function('modulePath', `return import(modulePath);`) as Exclude<
+    typeof load,
+    undefined
+  >;
+
+  return load(modulePath);
+}

--- a/packages/angular-rsbuild/src/lib/models/normalize-options.ts
+++ b/packages/angular-rsbuild/src/lib/models/normalize-options.ts
@@ -1,5 +1,5 @@
 import { FileReplacement } from '@nx/angular-rspack-compiler';
-import { PluginAngularOptions } from './plugin-options';
+import { PluginAngularOptions, type DevServerOptions } from './plugin-options';
 import { join, resolve } from 'node:path';
 import { existsSync } from 'node:fs';
 
@@ -100,6 +100,7 @@ export function normalizeOptions(
     server,
     ssr,
     optimization,
+    devServer,
     ...restOptions
   } = options;
 
@@ -126,5 +127,21 @@ export function normalizeOptions(
     optimization: normalizedOptimization,
     fileReplacements: resolveFileReplacements(fileReplacements, root),
     hasServer: getHasServer({ server, ssr: normalizedSsr, root }),
+    devServer: normalizeDevServer(devServer),
+  };
+}
+
+function normalizeDevServer(
+  devServer: DevServerOptions | undefined
+): DevServerOptions | undefined {
+  const defaultPort = 4200;
+
+  if (!devServer) {
+    return { port: defaultPort };
+  }
+
+  return {
+    ...devServer,
+    port: devServer.port ?? defaultPort,
   };
 }

--- a/packages/angular-rsbuild/src/lib/models/plugin-options.ts
+++ b/packages/angular-rsbuild/src/lib/models/plugin-options.ts
@@ -5,7 +5,11 @@ import type {
 } from '@nx/angular-rspack-compiler';
 
 export interface DevServerOptions {
-  port: number;
+  port?: number;
+  ssl?: boolean;
+  sslKey?: string;
+  sslCert?: string;
+  proxyConfig?: string;
 }
 
 export interface OptimizationOptions {

--- a/packages/angular-rspack/package.json
+++ b/packages/angular-rspack/package.json
@@ -45,14 +45,15 @@
     }
   },
   "dependencies": {
-    "less-loader": "^12.2.0",
-    "sass-loader": "^16.0.2",
-    "sass-embedded": "^1.79.3",
-    "tslib": "^2.3.0",
     "@nx/angular-rspack-compiler": "workspace:*",
+    "express": "4.21.1",
+    "jsonc-parser": "^3.3.1",
+    "less-loader": "^12.2.0",
+    "sass-embedded": "^1.79.3",
+    "sass-loader": "^16.0.2",
+    "tslib": "^2.3.0",
     "webpack-merge": "^6.0.1",
-    "ws": "^8.18.0",
-    "express": "4.21.1"
+    "ws": "^8.18.0"
   },
   "devDependencies": {
     "@ng-rspack/testing-setup": "workspace:*"

--- a/packages/angular-rspack/src/lib/config/create-config.unit.test.ts
+++ b/packages/angular-rspack/src/lib/config/create-config.unit.test.ts
@@ -26,19 +26,19 @@ describe('createConfig', () => {
     vi.stubEnv('NGRS_CONFIG', '');
   });
 
-  it('should create config for mode "production" if env variable NODE_ENV is "production"', () => {
+  it('should create config for mode "production" if env variable NODE_ENV is "production"', async () => {
     vi.stubEnv('NODE_ENV', 'production');
-    expect(_createConfig(configBase)).toStrictEqual([
+    await expect(_createConfig(configBase)).resolves.toStrictEqual([
       expect.objectContaining({ mode: 'production' }),
     ]);
   });
 
   it.each(['development', 'not-production'])(
     'should create config for mode "development" if env variable NODE_ENV is "%s"',
-    (nodeEnv) => {
+    async (nodeEnv) => {
       vi.stubEnv('NODE_ENV', nodeEnv);
 
-      expect(_createConfig(configBase)).toStrictEqual([
+      await expect(_createConfig(configBase)).resolves.toStrictEqual([
         expect.objectContaining({ mode: 'development' }),
       ]);
     }
@@ -65,8 +65,10 @@ describe('createConfig', () => {
       );
     };
 
-    it('should create config from options', () => {
-      expect(createConfig({ options: configBase })).toStrictEqual([
+    it('should create config from options', async () => {
+      await expect(
+        createConfig({ options: configBase })
+      ).resolves.toStrictEqual([
         expect.objectContaining({
           mode: 'development',
           devServer: expect.objectContaining({
@@ -89,10 +91,10 @@ describe('createConfig', () => {
       ]);
     });
 
-    it('should allow turning off optimizations', () => {
-      expect(
+    it('should allow turning off optimizations', async () => {
+      await expect(
         createConfig({ options: { ...configBase, optimization: false } })
-      ).toStrictEqual([
+      ).resolves.toStrictEqual([
         expect.objectContaining({
           mode: 'development',
           devServer: expect.objectContaining({
@@ -115,8 +117,8 @@ describe('createConfig', () => {
       ]);
     });
 
-    it('should allow changing the devServer port', () => {
-      expect(
+    it('should allow changing the devServer port', async () => {
+      await expect(
         createConfig({
           options: {
             ...configBase,
@@ -125,7 +127,7 @@ describe('createConfig', () => {
             },
           },
         })
-      ).toStrictEqual([
+      ).resolves.toStrictEqual([
         expect.objectContaining({
           devServer: expect.objectContaining({
             port: 8080,
@@ -139,10 +141,10 @@ describe('createConfig', () => {
       ['production', 'prod', false],
     ])(
       'should create config for mode "development" if env variable NGRS_CONFIG is "%s"',
-      (configuration, fileNameSegment, skipTypeChecking) => {
+      async (configuration, fileNameSegment, skipTypeChecking) => {
         vi.stubEnv('NGRS_CONFIG', configuration);
 
-        const config = runCreateConfig();
+        const config = await runCreateConfig();
 
         const plugins = config[0].plugins;
         const NgRspackPlugin = plugins?.find(

--- a/packages/angular-rspack/src/lib/config/dev-server-config-utils.ts
+++ b/packages/angular-rspack/src/lib/config/dev-server-config-utils.ts
@@ -1,0 +1,140 @@
+import type { DevServer } from '@rspack/core';
+import assert from 'node:assert';
+import { existsSync, promises as fsPromises } from 'node:fs';
+import { extname, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export async function getProxyConfig(
+  root: string,
+  proxyConfig: string | undefined
+): Promise<DevServer['proxy'] | undefined> {
+  if (!proxyConfig) {
+    return undefined;
+  }
+
+  const proxyPath = resolve(root, proxyConfig);
+
+  if (!existsSync(proxyPath)) {
+    throw new Error(`Proxy configuration file ${proxyPath} does not exist.`);
+  }
+
+  let proxyConfiguration: Record<string, object> | object[];
+
+  switch (extname(proxyPath)) {
+    case '.json': {
+      const content = await fsPromises.readFile(proxyPath, 'utf-8');
+
+      const { parse, printParseErrorCode } = await import('jsonc-parser');
+      const parseErrors: import('jsonc-parser').ParseError[] = [];
+      proxyConfiguration = parse(content, parseErrors, {
+        allowTrailingComma: true,
+      });
+
+      if (parseErrors.length > 0) {
+        let errorMessage = `Proxy configuration file ${proxyPath} contains parse errors:`;
+        for (const parseError of parseErrors) {
+          const { line, column } = getJsonErrorLineColumn(
+            parseError.offset,
+            content
+          );
+          errorMessage += `\n[${line}, ${column}] ${printParseErrorCode(
+            parseError.error
+          )}`;
+        }
+        throw new Error(errorMessage);
+      }
+
+      break;
+    }
+    case '.mjs':
+      // Load the ESM configuration file using the TypeScript dynamic import workaround.
+      // Once TypeScript provides support for keeping the dynamic import this workaround can be
+      // changed to a direct dynamic import.
+      proxyConfiguration = (
+        await loadEsmModule<{ default: Record<string, object> | object[] }>(
+          pathToFileURL(proxyPath)
+        )
+      ).default;
+      break;
+    case '.cjs':
+      proxyConfiguration = require(proxyPath);
+      break;
+    default:
+      // The file could be either CommonJS or ESM.
+      // CommonJS is tried first then ESM if loading fails.
+      try {
+        proxyConfiguration = require(proxyPath);
+      } catch (e) {
+        assertIsError(e);
+        if (e.code !== 'ERR_REQUIRE_ESM') {
+          throw e;
+        }
+
+        // Load the ESM configuration file using the TypeScript dynamic import workaround.
+        // Once TypeScript provides support for keeping the dynamic import this workaround can be
+        // changed to a direct dynamic import.
+        proxyConfiguration = (
+          await loadEsmModule<{ default: Record<string, object> | object[] }>(
+            pathToFileURL(proxyPath)
+          )
+        ).default;
+      }
+  }
+
+  return normalizeProxyConfiguration(proxyConfiguration);
+}
+
+function getJsonErrorLineColumn(offset: number, content: string) {
+  if (offset === 0) {
+    return { line: 1, column: 1 };
+  }
+
+  let line = 0;
+  let position = 0;
+  while (true) {
+    ++line;
+
+    const nextNewline = content.indexOf('\n', position);
+    if (nextNewline === -1 || nextNewline > offset) {
+      break;
+    }
+
+    position = nextNewline + 1;
+  }
+
+  return { line, column: offset - position + 1 };
+}
+
+function normalizeProxyConfiguration(
+  proxy: Record<string, object> | object[]
+): DevServer['proxy'] {
+  return Array.isArray(proxy)
+    ? proxy
+    : Object.entries(proxy).map(([context, value]) => ({
+        context: [context],
+        ...value,
+      }));
+}
+
+function assertIsError(
+  value: unknown
+): asserts value is Error & { code?: string } {
+  const isError =
+    value instanceof Error ||
+    // The following is needing to identify errors coming from RxJs.
+    (typeof value === 'object' &&
+      value &&
+      'name' in value &&
+      'message' in value);
+  assert(isError, 'catch clause variable is not an Error instance');
+}
+
+let load: (<T>(modulePath: string | URL) => Promise<T>) | undefined;
+function loadEsmModule<T>(modulePath: string | URL): Promise<T> {
+  load ??= new Function('modulePath', `return import(modulePath);`) as Exclude<
+    typeof load,
+    undefined
+  >;
+
+  return load(modulePath);
+}

--- a/packages/angular-rspack/src/lib/models/angular-rspack-plugin-options.ts
+++ b/packages/angular-rspack/src/lib/models/angular-rspack-plugin-options.ts
@@ -5,7 +5,11 @@ import type {
 } from '@nx/angular-rspack-compiler';
 
 export interface DevServerOptions {
-  port: number;
+  port?: number;
+  ssl?: boolean;
+  sslKey?: string;
+  sslCert?: string;
+  proxyConfig?: string;
 }
 
 export interface OptimizationOptions {

--- a/packages/angular-rspack/src/lib/models/normalize-options.ts
+++ b/packages/angular-rspack/src/lib/models/normalize-options.ts
@@ -1,5 +1,8 @@
 import { FileReplacement } from '@nx/angular-rspack-compiler';
-import { AngularRspackPluginOptions } from './angular-rspack-plugin-options';
+import type {
+  AngularRspackPluginOptions,
+  DevServerOptions,
+} from './angular-rspack-plugin-options';
 import { join, resolve } from 'node:path';
 import { existsSync } from 'node:fs';
 
@@ -111,13 +114,21 @@ export function normalizeOptions(
     hasServer: getHasServer({ server, ssr: normalizedSsr, root }),
     skipTypeChecking: options.skipTypeChecking ?? false,
     useTsProjectReferences: options.useTsProjectReferences ?? false,
-    devServer: options.devServer
-      ? {
-          ...options.devServer,
-          port: options.devServer.port ?? 4200,
-        }
-      : {
-          port: 4200,
-        },
+    devServer: normalizeDevServer(options.devServer),
+  };
+}
+
+function normalizeDevServer(
+  devServer: DevServerOptions | undefined
+): DevServerOptions | undefined {
+  const defaultPort = 4200;
+
+  if (!devServer) {
+    return { port: defaultPort };
+  }
+
+  return {
+    ...devServer,
+    port: devServer.port ?? defaultPort,
   };
 }

--- a/packages/angular-rspack/tsconfig.spec.json
+++ b/packages/angular-rspack/tsconfig.spec.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "type": "commonjs",
     "outDir": "../../dist/out-tsc",
     "types": [
       "vitest/globals",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -450,6 +450,9 @@ importers:
       express:
         specifier: 4.21.1
         version: 4.21.1
+      jsonc-parser:
+        specifier: ^3.3.1
+        version: 3.3.1
       sass-embedded:
         specifier: ^1.79.3
         version: 1.85.1
@@ -481,6 +484,9 @@ importers:
       express:
         specifier: 4.21.1
         version: 4.21.1
+      jsonc-parser:
+        specifier: ^3.3.1
+        version: 3.3.1
       less-loader:
         specifier: ^12.2.0
         version: 12.2.0(@rspack/core@1.2.6(@swc/helpers@0.5.15))(less@4.2.1)(webpack@5.98.0(@swc/core@1.5.29(@swc/helpers@0.5.15))(esbuild@0.19.12))


### PR DESCRIPTION
## Current Behaviour

Options `ssl`, `sslKey`, `sslCert`, and `proxyConfig` are not supported.

## Expected Behaviour

Options `ssl`, `sslKey`, `sslCert`, and `proxyConfig` should be supported.