### PR TITLE
feat(angular-rspack,angular-rsbuild): turn on/off advanced optimizations based on provided options

### DIFF
--- a/packages/angular-rsbuild/src/lib/config/create-config.unit.test.ts
+++ b/packages/angular-rsbuild/src/lib/config/create-config.unit.test.ts
@@ -3,7 +3,7 @@ import { beforeAll, beforeEach, expect } from 'vitest';
 import * as normalizeModule from '../models/normalize-options.ts';
 import { DEFAULT_PLUGIN_ANGULAR_OPTIONS } from '../models/normalize-options.ts';
 import * as rsbuildCoreModule from '@rsbuild/core';
-import { PluginAngularOptions } from '../models/plugin-options.ts';
+import type { NormalizedPluginAngularOptions } from '../models/plugin-options.ts';
 
 vi.mock('@rsbuild/core');
 
@@ -11,10 +11,17 @@ describe('createConfig', () => {
   const argvSpy = vi.spyOn(process, 'argv', 'get');
   const normalizeOptionsSpy = vi.spyOn(normalizeModule, 'normalizeOptions');
   const defineConfigSpy = vi.spyOn(rsbuildCoreModule, 'defineConfig');
+  const defaultNormalizedOptions: NormalizedPluginAngularOptions = {
+    ...DEFAULT_PLUGIN_ANGULAR_OPTIONS,
+    advancedOptimizations: true,
+    devServer: { port: 4200 },
+    optimization: true,
+    outputHashing: 'all',
+  };
 
   beforeAll(() => {
     argvSpy.mockReturnValue([]);
-    normalizeOptionsSpy.mockReturnValue(DEFAULT_PLUGIN_ANGULAR_OPTIONS);
+    normalizeOptionsSpy.mockReturnValue(defaultNormalizedOptions);
     defineConfigSpy.mockReturnValue({});
   });
 
@@ -49,7 +56,7 @@ describe('createConfig', () => {
   it('should have dev property defined if the process started with "dev" argument and a server is configured', async () => {
     argvSpy.mockReturnValue(['irrelevant', 'irrelevant', 'dev']);
     normalizeOptionsSpy.mockReturnValue({
-      ...DEFAULT_PLUGIN_ANGULAR_OPTIONS,
+      ...defaultNormalizedOptions,
       ssr: { entry: 'main.ts' },
       hasServer: true,
     });
@@ -86,7 +93,7 @@ describe('createConfig', () => {
   it('should used definedConfig for both passed objects', async () => {
     defineConfigSpy.mockImplementation((config) => config);
     normalizeOptionsSpy.mockImplementation(
-      (options) => options as PluginAngularOptions
+      (options) => options as NormalizedPluginAngularOptions
     );
 
     await expect(
@@ -122,7 +129,7 @@ describe('createConfig', () => {
   it('should allow changing the devServer port', async () => {
     defineConfigSpy.mockImplementation((config) => config);
     normalizeOptionsSpy.mockImplementation(
-      (options) => options as PluginAngularOptions
+      (options) => options as NormalizedPluginAngularOptions
     );
 
     await expect(

--- a/packages/angular-rsbuild/src/lib/models/normalize-options.unit.test.ts
+++ b/packages/angular-rsbuild/src/lib/models/normalize-options.unit.test.ts
@@ -129,13 +129,19 @@ describe('normalizeOptions', () => {
   it('should apply default values when no options are provided', () => {
     const result = normalizeOptions();
 
-    expect(result).toStrictEqual(defaultOptions);
+    expect(result).toStrictEqual({
+      ...defaultOptions,
+      advancedOptimizations: true,
+    });
   });
 
   it('should apply default values when empty options are provided', () => {
     const result = normalizeOptions({});
 
-    expect(result).toStrictEqual(defaultOptions);
+    expect(result).toStrictEqual({
+      ...defaultOptions,
+      advancedOptimizations: true,
+    });
   });
 
   it('should apply provides options', () => {
@@ -143,6 +149,7 @@ describe('normalizeOptions', () => {
 
     expect(result).toStrictEqual({
       ...defaultOptions,
+      advancedOptimizations: true,
       root: 'project-root',
     });
   });

--- a/packages/angular-rsbuild/src/lib/models/plugin-options.ts
+++ b/packages/angular-rsbuild/src/lib/models/plugin-options.ts
@@ -53,3 +53,10 @@ export interface PluginAngularOptions {
   stylePreprocessorOptions?: StylePreprocessorOptions;
   devServer?: DevServerOptions;
 }
+
+export interface NormalizedPluginAngularOptions extends PluginAngularOptions {
+  advancedOptimizations: boolean;
+  devServer: DevServerOptions & { port: number };
+  optimization: boolean | OptimizationOptions;
+  outputHashing: OutputHashing;
+}

--- a/packages/angular-rsbuild/src/lib/plugin/plugin-angular.ts
+++ b/packages/angular-rsbuild/src/lib/plugin/plugin-angular.ts
@@ -4,7 +4,7 @@ import {
   TemplateUrlsResolver,
   TS_ALL_EXT_REGEX,
 } from '@nx/angular-rspack-compiler';
-import { PluginAngularOptions } from '../models/plugin-options';
+import type { NormalizedPluginAngularOptions } from '../models/plugin-options';
 import { normalizeOptions } from '../models/normalize-options';
 import { dirname, normalize, resolve } from 'path';
 import { pluginAngularJit } from './plugin-angular-jit';
@@ -12,7 +12,7 @@ import { ChildProcess, fork } from 'node:child_process';
 import { readFileSync } from 'fs';
 
 export const pluginAngular = (
-  options: Partial<PluginAngularOptions> = {}
+  options: Partial<NormalizedPluginAngularOptions> = {}
 ): RsbuildPlugin => ({
   name: 'plugin-angular',
   pre: ['plugin-hoisted-js-transformer'],

--- a/packages/angular-rsbuild/src/lib/plugin/plugin-hoisted-js-transformer.ts
+++ b/packages/angular-rsbuild/src/lib/plugin/plugin-hoisted-js-transformer.ts
@@ -8,11 +8,11 @@ import {
   setupCompilationWithParallelCompilation,
   PartialMessage,
 } from '@nx/angular-rspack-compiler';
-import { PluginAngularOptions } from '../models/plugin-options';
+import type { NormalizedPluginAngularOptions } from '../models/plugin-options';
 import { normalizeOptions } from '../models/normalize-options';
 
 export const pluginHoistedJsTransformer = (
-  options: PluginAngularOptions
+  options: NormalizedPluginAngularOptions
 ): RsbuildPlugin => ({
   name: 'plugin-hoisted-js-transformer',
   post: ['plugin-angular'],
@@ -30,6 +30,7 @@ export const pluginHoistedJsTransformer = (
       {
         sourcemap: false,
         thirdPartySourcemaps: false,
+        // @TODO: it should be `pluginOptions.advancedOptimizations` but it currently fails the build
         advancedOptimizations: false,
         jit: !pluginOptions.aot,
       },

--- a/packages/angular-rspack/src/lib/config/create-config.unit.test.ts
+++ b/packages/angular-rspack/src/lib/config/create-config.unit.test.ts
@@ -79,6 +79,7 @@ describe('createConfig', () => {
               pluginOptions: {
                 ...configBase,
                 optimization: true,
+                advancedOptimizations: true,
                 useTsProjectReferences: false,
                 polyfills: ['zone.js'],
                 devServer: {
@@ -105,6 +106,7 @@ describe('createConfig', () => {
               pluginOptions: {
                 ...configBase,
                 optimization: false,
+                advancedOptimizations: false,
                 useTsProjectReferences: false,
                 polyfills: ['zone.js'],
                 devServer: {

--- a/packages/angular-rspack/src/lib/models/angular-rspack-plugin-options.ts
+++ b/packages/angular-rspack/src/lib/models/angular-rspack-plugin-options.ts
@@ -53,3 +53,11 @@ export interface AngularRspackPluginOptions {
   stylePreprocessorOptions?: StylePreprocessorOptions;
   devServer?: DevServerOptions;
 }
+
+export interface NormalizedAngularRspackPluginOptions
+  extends AngularRspackPluginOptions {
+  advancedOptimizations: boolean;
+  devServer: DevServerOptions & { port: number };
+  optimization: boolean | OptimizationOptions;
+  outputHashing: OutputHashing;
+}

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
@@ -5,9 +5,9 @@ import {
   RspackPluginInstance,
 } from '@rspack/core';
 import {
-  AngularRspackPluginOptions,
   NG_RSPACK_SYMBOL_NAME,
   NgRspackCompilation,
+  type NormalizedAngularRspackPluginOptions,
 } from '../models';
 import {
   maxWorkers,
@@ -26,7 +26,7 @@ type ResolvedJavascriptTransformer = Parameters<
 >[2];
 
 export class AngularRspackPlugin implements RspackPluginInstance {
-  #_options: AngularRspackPluginOptions;
+  #_options: NormalizedAngularRspackPluginOptions;
   #typescriptFileCache: Map<string, string>;
   #javascriptTransformer: ResolvedJavascriptTransformer;
   // This will be defined in the apply method correctly
@@ -36,14 +36,14 @@ export class AngularRspackPlugin implements RspackPluginInstance {
     ReturnType<typeof setupCompilationWithParallelCompilation>
   >;
 
-  constructor(options: AngularRspackPluginOptions) {
+  constructor(options: NormalizedAngularRspackPluginOptions) {
     this.#_options = options;
     this.#typescriptFileCache = new Map<string, string>();
     this.#javascriptTransformer = new JavaScriptTransformer(
       {
         sourcemap: false,
         thirdPartySourcemaps: false,
-        advancedOptimizations: true,
+        advancedOptimizations: this.#_options.advancedOptimizations,
         jit: !this.#_options.aot,
       },
       maxWorkers()

--- a/packages/angular-rspack/src/lib/plugins/ng-rspack.ts
+++ b/packages/angular-rspack/src/lib/plugins/ng-rspack.ts
@@ -10,13 +10,13 @@ import {
 import { basename, extname, join } from 'path';
 import { RxjsEsmResolutionPlugin } from './rxjs-esm-resolution';
 import { AngularRspackPlugin } from './angular-rspack-plugin';
-import { AngularRspackPluginOptions } from '../models';
+import type { NormalizedAngularRspackPluginOptions } from '../models';
 import { AngularSsrDevServer } from './angular-ssr-dev-server';
 
 export class NgRspackPlugin implements RspackPluginInstance {
-  pluginOptions: AngularRspackPluginOptions;
+  pluginOptions: NormalizedAngularRspackPluginOptions;
 
-  constructor(options: AngularRspackPluginOptions) {
+  constructor(options: NormalizedAngularRspackPluginOptions) {
     this.pluginOptions = options;
   }
 


### PR DESCRIPTION
## Current Behaviour

The advanced optimizations performed by the JS transformer are not disabled when `aot: false` or `optimizations: false`

## Expected Behaviour

The advanced optimizations performed by the JS transformer should be disabled when `aot: false` or `optimizations: false`.

Note: they should be disabled when `aot === false && optimizations.scripts === false`, but the fine-grained optimizations are not yet supported.