### PR TITLE
feat(angular-rspack): support `extractLicenses` option

### DIFF
--- a/e2e/fixtures/rspack-csr-css/rspack.config.js
+++ b/e2e/fixtures/rspack-csr-css/rspack.config.js
@@ -2,27 +2,37 @@ module.exports = () => {
   if (global.NX_GRAPH_CREATION === undefined) {
     const { join } = require('path');
     const { createConfig } = require('@nx/angular-rspack');
-    return createConfig({
-      options: {
-        name: 'rspack-csr-css',
-        index: './src/index.html',
-        assets: [{ glob: '**/*', input: 'public' }],
-        styles: ['./src/styles.css'],
-        polyfills: ['zone.js'],
-        main: './src/main.ts',
-        outputPath: {
-          base: './build',
-          browser: './build/static',
-        },
-        outputHashing: 'none',
-        tsConfig: join(__dirname, './tsconfig.app.json'),
-        skipTypeChecking: false,
-        devServer: {
-          port: 8080,
-          proxyConfig: './proxy.conf.json',
+    return createConfig(
+      {
+        options: {
+          name: 'rspack-csr-css',
+          index: './src/index.html',
+          assets: [{ glob: '**/*', input: 'public' }],
+          styles: ['./src/styles.css'],
+          polyfills: ['zone.js'],
+          main: './src/main.ts',
+          outputPath: {
+            base: './build',
+            browser: './build/static',
+          },
+          outputHashing: 'none',
+          tsConfig: join(__dirname, './tsconfig.app.json'),
+          skipTypeChecking: false,
+          devServer: {
+            port: 8080,
+            proxyConfig: './proxy.conf.json',
+          },
         },
       },
-    });
+      {
+        development: {
+          options: {
+            extractLicenses: false,
+            optimization: false,
+          },
+        },
+      }
+    );
   }
   return {};
 };

--- a/packages/angular-rspack/package.json
+++ b/packages/angular-rspack/package.json
@@ -73,7 +73,7 @@
       "code-pushup": {},
       "unit-test": {
         "dependsOn": [
-          "^build"
+          "build"
         ]
       }
     }

--- a/packages/angular-rspack/package.json
+++ b/packages/angular-rspack/package.json
@@ -50,6 +50,7 @@
     "express": "4.21.1",
     "jsonc-parser": "^3.3.1",
     "less-loader": "^12.2.0",
+    "license-webpack-plugin": "^4.0.2",
     "sass-embedded": "^1.79.3",
     "sass-loader": "^16.0.2",
     "tslib": "^2.3.0",

--- a/packages/angular-rspack/src/lib/models/angular-rspack-plugin-options.ts
+++ b/packages/angular-rspack/src/lib/models/angular-rspack-plugin-options.ts
@@ -97,6 +97,7 @@ export interface AngularRspackPluginOptions {
   outputHashing?: OutputHashing;
   stylePreprocessorOptions?: StylePreprocessorOptions;
   devServer?: DevServerOptions;
+  extractLicenses?: boolean;
 }
 
 export interface NormalizedAngularRspackPluginOptions
@@ -105,6 +106,7 @@ export interface NormalizedAngularRspackPluginOptions
   assets: NormalizedAssetElement[];
   index: NormalizedIndexElement | undefined;
   devServer: DevServerOptions & { port: number };
+  extractLicenses: boolean;
   globalScripts: GlobalEntry[];
   globalStyles: GlobalEntry[];
   optimization: boolean | OptimizationOptions;

--- a/packages/angular-rspack/src/lib/models/normalize-options.ts
+++ b/packages/angular-rspack/src/lib/models/normalize-options.ts
@@ -222,6 +222,7 @@ export function normalizeOptions(
     skipTypeChecking: options.skipTypeChecking ?? false,
     useTsProjectReferences: options.useTsProjectReferences ?? false,
     devServer: normalizeDevServer(options.devServer),
+    extractLicenses: options.extractLicenses ?? true,
   };
 }
 

--- a/packages/angular-rspack/src/lib/plugins/ng-rspack.ts
+++ b/packages/angular-rspack/src/lib/plugins/ng-rspack.ts
@@ -7,7 +7,7 @@ import {
   ProgressPlugin,
   RspackPluginInstance,
 } from '@rspack/core';
-import { resolve } from 'node:path';
+import { posix, relative, resolve } from 'node:path';
 import { RxjsEsmResolutionPlugin } from './rxjs-esm-resolution';
 import { AngularRspackPlugin } from './angular-rspack-plugin';
 import { NormalizedAngularRspackPluginOptions, OutputPath } from '../models';
@@ -112,6 +112,24 @@ export class NgRspackPlugin implements RspackPluginInstance {
           };
         }),
       }).apply(compiler);
+    }
+    if (this.pluginOptions.extractLicenses) {
+      const { LicenseWebpackPlugin } = require('license-webpack-plugin');
+      new LicenseWebpackPlugin({
+        stats: {
+          warnings: false,
+          errors: false,
+        },
+        perChunkOutput: false,
+        outputFilename: posix.join(
+          relative(
+            this.pluginOptions.outputPath.browser,
+            this.pluginOptions.outputPath.base
+          ),
+          '3rdpartylicenses.txt'
+        ),
+        skipChildCompilers: true,
+      }).apply(compiler as any);
     }
     new RxjsEsmResolutionPlugin().apply(compiler);
     new AngularRspackPlugin(this.pluginOptions).apply(compiler);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -493,6 +493,9 @@ importers:
       less-loader:
         specifier: ^12.2.0
         version: 12.2.0(@rspack/core@1.2.6(@swc/helpers@0.5.15))(less@4.2.1)(webpack@5.98.0(@swc/core@1.5.29(@swc/helpers@0.5.15))(esbuild@0.19.12))
+      license-webpack-plugin:
+        specifier: ^4.0.2
+        version: 4.0.2(webpack@5.98.0(@swc/core@1.5.29(@swc/helpers@0.5.15))(esbuild@0.19.12))
       sass-embedded:
         specifier: ^1.79.3
         version: 1.85.1


### PR DESCRIPTION
Add support for the `extractLicenses` option.