### PR TITLE
fix(angular-rspack): sass-loader should not be required when using css

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@vitest/ui": "^1.3.1",
     "angular-eslint": "^19.0.2",
     "commitlint-plugin-tense": "1.0.4",
+    "css-loader": "^7.1.2",
     "eslint": "^9.8.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-playwright": "^1.6.2",

--- a/packages/angular-rspack/eslint.next.config.js
+++ b/packages/angular-rspack/eslint.next.config.js
@@ -24,6 +24,7 @@ module.exports = [
           ],
           ignoredDependencies: [
             'nx',
+            'css-loader',
             'less-loader',
             'sass-loader',
             'sass-embedded',

--- a/packages/angular-rspack/package.json
+++ b/packages/angular-rspack/package.json
@@ -54,6 +54,7 @@
     "license-webpack-plugin": "^4.0.2",
     "sass-embedded": "^1.79.3",
     "sass-loader": "^16.0.2",
+    "css-loader": "^7.1.2",
     "tslib": "^2.3.0",
     "webpack-merge": "^6.0.1",
     "ws": "^8.18.0"

--- a/packages/angular-rspack/src/lib/config/style-config-utils.ts
+++ b/packages/angular-rspack/src/lib/config/style-config-utils.ts
@@ -18,7 +18,7 @@ export function getSassLoaderConfig(
   sourceMap?: SourceMap
 ) {
   return {
-    test: /\.?(sa|sc|c)ss$/,
+    test: /\.?(sa|sc)ss$/,
     use: [
       {
         loader: 'sass-loader',
@@ -55,6 +55,18 @@ export function getLessLoaderConfig(
   };
 }
 
+export function getCssLoaderConfig(sourceMap?: SourceMap) {
+  return {
+    test: /\.css$/,
+    loader: require.resolve('css-loader'),
+    options: {
+      url: false,
+      sourceMap: sourceMap?.styles,
+      importLoaders: 1,
+    },
+  };
+}
+
 /**
  * Returns an array of style loaders for sass and less. Both loader´s are always returned
  *
@@ -69,6 +81,7 @@ export function getStyleLoaders(
     getIncludePathOptions(stylePreprocessorOptions?.includePaths);
 
   return [
+    getCssLoaderConfig(sourceMap),
     getSassLoaderConfig(
       sassPathOptions,
       stylePreprocessorOptions?.sass,

--- a/packages/angular-rspack/src/lib/config/style-config-utils.ts
+++ b/packages/angular-rspack/src/lib/config/style-config-utils.ts
@@ -55,18 +55,6 @@ export function getLessLoaderConfig(
   };
 }
 
-export function getCssLoaderConfig(sourceMap?: SourceMap) {
-  return {
-    test: /\.css$/,
-    loader: require.resolve('css-loader'),
-    options: {
-      url: false,
-      sourceMap: sourceMap?.styles,
-      importLoaders: 1,
-    },
-  };
-}
-
 /**
  * Returns an array of style loaders for sass and less. Both loader´s are always returned
  *
@@ -81,7 +69,6 @@ export function getStyleLoaders(
     getIncludePathOptions(stylePreprocessorOptions?.includePaths);
 
   return [
-    getCssLoaderConfig(sourceMap),
     getSassLoaderConfig(
       sassPathOptions,
       stylePreprocessorOptions?.sass,

--- a/packages/angular-rspack/src/lib/config/style-config-utils.unit.test.ts
+++ b/packages/angular-rspack/src/lib/config/style-config-utils.unit.test.ts
@@ -43,7 +43,7 @@ describe('getIncludePathOptions', () => {
 describe('getSassLoaderConfig', () => {
   it('should return sass loader config without options passed', () => {
     expect(getSassLoaderConfig()).toStrictEqual({
-      test: /\.?(sa|sc|c)ss$/,
+      test: /\.?(sa|sc)ss$/,
       use: [
         {
           loader: 'sass-loader',
@@ -127,7 +127,7 @@ describe('getStyleLoaders', () => {
   it('should return sass and less loader config without options passed', () => {
     expect(getStyleLoaders()).toStrictEqual([
       {
-        test: /\.?(sa|sc|c)ss$/,
+        test: /\.?(sa|sc)ss$/,
         use: [
           {
             loader: 'sass-loader',
@@ -162,26 +162,28 @@ describe('getStyleLoaders', () => {
         includePaths: ['path/to/a'],
         sass: { indentedSyntax: true },
       })
-    ).toStrictEqual([
-      expect.objectContaining({
-        use: [
-          expect.objectContaining({
-            options: expect.objectContaining({
-              includePaths: ['path/to/a'],
-              indentedSyntax: true,
+    ).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          use: [
+            expect.objectContaining({
+              options: expect.objectContaining({
+                includePaths: ['path/to/a'],
+                indentedSyntax: true,
+              }),
             }),
-          }),
-        ],
-      }),
-      expect.objectContaining({
-        use: [
-          expect.objectContaining({
-            options: expect.objectContaining({
-              paths: ['path/to/a'],
+          ],
+        }),
+        expect.objectContaining({
+          use: [
+            expect.objectContaining({
+              options: expect.objectContaining({
+                paths: ['path/to/a'],
+              }),
             }),
-          }),
-        ],
-      }),
-    ]);
+          ],
+        }),
+      ])
+    );
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -484,6 +484,9 @@ importers:
       '@rspack/core':
         specifier: '>=1.0.5 <2.0.0'
         version: 1.2.6(@swc/helpers@0.5.15)
+      css-loader:
+        specifier: ^7.1.2
+        version: 7.1.2(@rspack/core@1.2.6(@swc/helpers@0.5.15))(webpack@5.98.0(@swc/core@1.5.29(@swc/helpers@0.5.15))(esbuild@0.19.12))
       express:
         specifier: 4.21.1
         version: 4.21.1
@@ -15784,17 +15787,31 @@ snapshots:
 
   css-loader@7.1.2(@rspack/core@1.2.6(@swc/helpers@0.5.15))(webpack@5.97.1(@swc/core@1.5.29(@swc/helpers@0.5.15))(esbuild@0.24.2)):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.4.49)
-      postcss: 8.4.49
-      postcss-modules-extract-imports: 3.1.0(postcss@8.4.49)
-      postcss-modules-local-by-default: 4.2.0(postcss@8.4.49)
-      postcss-modules-scope: 3.2.1(postcss@8.4.49)
-      postcss-modules-values: 4.0.0(postcss@8.4.49)
+      icss-utils: 5.1.0(postcss@8.5.3)
+      postcss: 8.5.3
+      postcss-modules-extract-imports: 3.1.0(postcss@8.5.3)
+      postcss-modules-local-by-default: 4.2.0(postcss@8.5.3)
+      postcss-modules-scope: 3.2.1(postcss@8.5.3)
+      postcss-modules-values: 4.0.0(postcss@8.5.3)
       postcss-value-parser: 4.2.0
-      semver: 7.6.3
+      semver: 7.7.1
     optionalDependencies:
       '@rspack/core': 1.2.6(@swc/helpers@0.5.15)
       webpack: 5.97.1(@swc/core@1.5.29(@swc/helpers@0.5.15))(esbuild@0.24.2)
+
+  css-loader@7.1.2(@rspack/core@1.2.6(@swc/helpers@0.5.15))(webpack@5.98.0(@swc/core@1.5.29(@swc/helpers@0.5.15))(esbuild@0.19.12)):
+    dependencies:
+      icss-utils: 5.1.0(postcss@8.5.3)
+      postcss: 8.5.3
+      postcss-modules-extract-imports: 3.1.0(postcss@8.5.3)
+      postcss-modules-local-by-default: 4.2.0(postcss@8.5.3)
+      postcss-modules-scope: 3.2.1(postcss@8.5.3)
+      postcss-modules-values: 4.0.0(postcss@8.5.3)
+      postcss-value-parser: 4.2.0
+      semver: 7.7.1
+    optionalDependencies:
+      '@rspack/core': 1.2.6(@swc/helpers@0.5.15)
+      webpack: 5.98.0(@swc/core@1.5.29(@swc/helpers@0.5.15))(esbuild@0.19.12)
 
   css-minimizer-webpack-plugin@5.0.1(esbuild@0.19.12)(webpack@5.98.0(@swc/core@1.5.29(@swc/helpers@0.5.15))(esbuild@0.19.12)):
     dependencies:
@@ -17142,10 +17159,6 @@ snapshots:
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
-
-  icss-utils@5.1.0(postcss@8.4.49):
-    dependencies:
-      postcss: 8.4.49
 
   icss-utils@5.1.0(postcss@8.5.3):
     dependencies:
@@ -19017,20 +19030,9 @@ snapshots:
       postcss: 8.5.3
       postcss-selector-parser: 6.1.2
 
-  postcss-modules-extract-imports@3.1.0(postcss@8.4.49):
-    dependencies:
-      postcss: 8.4.49
-
   postcss-modules-extract-imports@3.1.0(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
-
-  postcss-modules-local-by-default@4.2.0(postcss@8.4.49):
-    dependencies:
-      icss-utils: 5.1.0(postcss@8.4.49)
-      postcss: 8.4.49
-      postcss-selector-parser: 7.1.0
-      postcss-value-parser: 4.2.0
 
   postcss-modules-local-by-default@4.2.0(postcss@8.5.3):
     dependencies:
@@ -19039,20 +19041,10 @@ snapshots:
       postcss-selector-parser: 7.1.0
       postcss-value-parser: 4.2.0
 
-  postcss-modules-scope@3.2.1(postcss@8.4.49):
-    dependencies:
-      postcss: 8.4.49
-      postcss-selector-parser: 7.1.0
-
   postcss-modules-scope@3.2.1(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
       postcss-selector-parser: 7.1.0
-
-  postcss-modules-values@4.0.0(postcss@8.4.49):
-    dependencies:
-      icss-utils: 5.1.0(postcss@8.4.49)
-      postcss: 8.4.49
 
   postcss-modules-values@4.0.0(postcss@8.5.3):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -255,6 +255,9 @@ importers:
       commitlint-plugin-tense:
         specifier: 1.0.4
         version: 1.0.4(@commitlint/lint@19.7.1)
+      css-loader:
+        specifier: ^7.1.2
+        version: 7.1.2(@rspack/core@1.2.6(@swc/helpers@0.5.15))(webpack@5.98.0(@swc/core@1.5.29(@swc/helpers@0.5.15))(esbuild@0.19.12))
       eslint:
         specifier: ^9.8.0
         version: 9.21.0(jiti@2.4.2)


### PR DESCRIPTION
- fix(angular-rspack): sass-loader should not be required when using css
- fix(angular-rspack): sass-loader should not be required when using css
