### PR TITLE
feat(angular-rspack,angular-rsbuild): add `root` option and improve `tsConfig` handling

### DIFF
--- a/e2e/fixtures/rspack-csr-css/rspack.config.js
+++ b/e2e/fixtures/rspack-csr-css/rspack.config.js
@@ -1,10 +1,10 @@
 module.exports = () => {
   if (global.NX_GRAPH_CREATION === undefined) {
-    const { join } = require('path');
     const { createConfig } = require('@nx/angular-rspack');
     return createConfig(
       {
         options: {
+          root: __dirname,
           name: 'rspack-csr-css',
           index: './src/index.html',
           assets: [{ glob: '**/*', input: 'public' }],
@@ -20,7 +20,7 @@ module.exports = () => {
             styles: true,
           },
           outputHashing: 'none',
-          tsConfig: join(__dirname, './tsconfig.app.json'),
+          tsConfig: './tsconfig.app.json',
           skipTypeChecking: false,
           devServer: {
             port: 8080,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -45,7 +45,8 @@ module.exports = tseslint.config(
       '**/__snapshots__/**',
       '**/dist',
       '**/*.md',
-      'e2e/fixtures/**/build',
+      '**/build',
+      '!packages/build',
     ],
   }
 );

--- a/packages/angular-rsbuild/src/lib/config/create-config.ts
+++ b/packages/angular-rsbuild/src/lib/config/create-config.ts
@@ -89,7 +89,7 @@ export async function _createConfig(
     }
   }
 
-  const root = process.cwd();
+  const { root } = normalizedOptions;
   const rsbuildPluginAngularConfig = defineConfig({
     root,
     source: {

--- a/packages/angular-rsbuild/src/lib/models/normalize-options.ts
+++ b/packages/angular-rsbuild/src/lib/models/normalize-options.ts
@@ -26,11 +26,11 @@ export function resolveFileReplacements(
   }));
 }
 
-export function getHasServer({
-  server,
-  ssr,
-}: Pick<PluginAngularOptions, 'server' | 'ssr'>): boolean {
-  const root = process.cwd();
+export function getHasServer(
+  root: string,
+  server: string | undefined,
+  ssr: PluginAngularOptions['ssr']
+): boolean {
   return !!(
     server &&
     ssr &&
@@ -114,7 +114,7 @@ export const DEFAULT_PLUGIN_ANGULAR_OPTIONS: PluginAngularOptions = {
 export function normalizeOptions(
   options: Partial<PluginAngularOptions> = {}
 ): NormalizedPluginAngularOptions {
-  const root = process.cwd();
+  const root = options.root ?? process.cwd();
   const {
     fileReplacements = [],
     server,
@@ -139,6 +139,9 @@ export function normalizeOptions(
   const normalizedOptimization = optimization !== false; // @TODO: Add support for optimization options
   const aot = options.aot ?? true;
   const advancedOptimizations = aot && normalizedOptimization;
+  const tsConfig = options.tsConfig
+    ? resolve(root, options.tsConfig)
+    : join(root, 'tsconfig.app.json');
 
   validateChunkOptions(options);
 
@@ -155,8 +158,10 @@ export function normalizeOptions(
     outputHashing: options.outputHashing ?? 'all',
     namedChunks: options.namedChunks ?? false,
     fileReplacements: resolveFileReplacements(fileReplacements, root),
-    hasServer: getHasServer({ server, ssr: normalizedSsr }),
+    hasServer: getHasServer(root, server, normalizedSsr),
     devServer: normalizeDevServer(devServer),
+    root,
+    tsConfig,
   };
 }
 

--- a/packages/angular-rsbuild/src/lib/models/normalize-options.unit.test.ts
+++ b/packages/angular-rsbuild/src/lib/models/normalize-options.unit.test.ts
@@ -1,3 +1,6 @@
+import { MEMFS_VOLUME } from '@ng-rspack/testing-utils';
+import { vol } from 'memfs';
+import { join } from 'node:path';
 import { describe, expect } from 'vitest';
 import {
   DEFAULT_PLUGIN_ANGULAR_OPTIONS,
@@ -6,9 +9,6 @@ import {
   normalizeOutputPath,
   resolveFileReplacements,
 } from './normalize-options.ts';
-import { vol } from 'memfs';
-
-import { MEMFS_VOLUME } from '@ng-rspack/testing-utils';
 import { PluginAngularOptions } from './plugin-options';
 
 describe('resolveFileReplacements', () => {
@@ -60,58 +60,52 @@ describe('getHasServer', () => {
   });
 
   it('should return true if both server and ssr.entry files exist', () => {
-    const result = getHasServer({
-      server: 'server.js',
-      ssr: { entry: 'ssr-entry.js' },
+    const result = getHasServer(process.cwd(), 'server.js', {
+      entry: 'ssr-entry.js',
     });
 
     expect(result).toBe(true);
   });
 
   it('should return false if server file is not provides', () => {
-    const result = getHasServer({
-      ssr: { entry: 'ssr-entry.js' },
+    const result = getHasServer(process.cwd(), undefined, {
+      entry: 'ssr-entry.js',
     });
 
     expect(result).toBe(false);
   });
 
   it('should return false if ssr.entry file is not provides', () => {
-    const result = getHasServer({
-      server: 'server.js',
-    });
+    const result = getHasServer(process.cwd(), 'server.js', undefined);
 
     expect(result).toBe(false);
   });
 
   it('should return false if neither file are not provides', () => {
-    const result = getHasServer({});
+    const result = getHasServer(process.cwd(), undefined, undefined);
 
     expect(result).toBe(false);
   });
 
   it('should return false if server file does not exist', () => {
-    const result = getHasServer({
-      server: 'non-existing-server.js',
-      ssr: { entry: 'ssr-entry.js' },
+    const result = getHasServer(process.cwd(), 'non-existing-server.js', {
+      entry: 'ssr-entry.js',
     });
 
     expect(result).toBe(false);
   });
 
   it('should return false if ssr.entry file does not exist', () => {
-    const result = getHasServer({
-      server: 'server.js',
-      ssr: { entry: 'non-existing-ssr-entry.js' },
+    const result = getHasServer(process.cwd(), 'server.js', {
+      entry: 'non-existing-ssr-entry.js',
     });
 
     expect(result).toBe(false);
   });
 
   it('should return false if neither server nor ssr.entry exists', () => {
-    const result = getHasServer({
-      server: 'non-existing-server.js',
-      ssr: { entry: 'non-existing-ssr-entry.js' },
+    const result = getHasServer(process.cwd(), 'non-existing-server.js', {
+      entry: 'non-existing-ssr-entry.js',
     });
 
     expect(result).toBe(false);
@@ -140,6 +134,8 @@ describe('normalizeOptions', () => {
 
     expect(result).toStrictEqual({
       ...defaultOptions,
+      root: process.cwd(),
+      tsConfig: join(process.cwd(), 'tsconfig.app.json'),
       advancedOptimizations: true,
     });
   });
@@ -149,6 +145,8 @@ describe('normalizeOptions', () => {
 
     expect(result).toStrictEqual({
       ...defaultOptions,
+      root: process.cwd(),
+      tsConfig: join(process.cwd(), 'tsconfig.app.json'),
       advancedOptimizations: true,
     });
   });
@@ -158,6 +156,8 @@ describe('normalizeOptions', () => {
 
     expect(result).toStrictEqual({
       ...defaultOptions,
+      root: process.cwd(),
+      tsConfig: join(process.cwd(), 'tsconfig.app.json'),
       optimization: false,
       advancedOptimizations: false,
     });

--- a/packages/angular-rsbuild/src/lib/models/plugin-options.ts
+++ b/packages/angular-rsbuild/src/lib/models/plugin-options.ts
@@ -70,6 +70,7 @@ export interface PluginAngularOptions {
   vendorChunk?: boolean;
   stylePreprocessorOptions?: StylePreprocessorOptions;
   devServer?: DevServerOptions;
+  root?: string;
 }
 
 export interface NormalizedPluginAngularOptions extends PluginAngularOptions {
@@ -78,5 +79,6 @@ export interface NormalizedPluginAngularOptions extends PluginAngularOptions {
   optimization: boolean | OptimizationOptions;
   outputHashing: OutputHashing;
   outputPath: OutputPath;
+  root: string;
   sourceMap: SourceMap;
 }

--- a/packages/angular-rspack/src/lib/config/create-config.ts
+++ b/packages/angular-rspack/src/lib/config/create-config.ts
@@ -86,7 +86,7 @@ export async function _createConfig(
   const normalizedOptions = normalizeOptions(options);
   const isProduction = process.env['NODE_ENV'] === 'production';
   const hashFormat = getOutputHashFormat(normalizedOptions.outputHashing);
-  const root = process.cwd();
+  const { root } = normalizedOptions;
 
   const { sourceMapRules, sourceMapPlugins } = configureSourceMap(
     normalizedOptions.sourceMap

--- a/packages/angular-rspack/src/lib/config/create-config.unit.test.ts
+++ b/packages/angular-rspack/src/lib/config/create-config.unit.test.ts
@@ -88,13 +88,14 @@ describe('createConfig', () => {
                   media: join(process.cwd(), 'dist', 'browser', 'media'),
                 },
                 index: expect.objectContaining({
-                  input: expect.stringMatching(/\/src\/index\.html$/),
+                  input: join(process.cwd(), 'src/index.html'),
                   insertionOrder: [
                     ['polyfills', true],
                     ['main', true],
                   ],
                   output: 'index.html',
                 }),
+                tsConfig: join(process.cwd(), 'tsconfig.base.json'),
                 sourceMap: {
                   scripts: true,
                   styles: true,
@@ -110,6 +111,44 @@ describe('createConfig', () => {
                 devServer: {
                   port: 4200,
                 },
+              }),
+            },
+          ]),
+        }),
+      ]);
+    });
+
+    it('should create config from options with a custom root', async () => {
+      const customRoot = join(process.cwd(), 'custom-root');
+
+      await expect(
+        createConfig({
+          options: { ...configBase, root: customRoot },
+        })
+      ).resolves.toStrictEqual([
+        expect.objectContaining({
+          mode: 'development',
+          devServer: expect.objectContaining({
+            port: 4200,
+          }),
+          plugins: expect.arrayContaining([
+            {
+              pluginOptions: expect.objectContaining({
+                outputPath: {
+                  base: join(customRoot, 'dist'),
+                  browser: join(customRoot, 'dist', 'browser'),
+                  server: join(customRoot, 'dist', 'server'),
+                  media: join(customRoot, 'dist', 'browser', 'media'),
+                },
+                index: expect.objectContaining({
+                  input: join(customRoot, 'src/index.html'),
+                  insertionOrder: [
+                    ['polyfills', true],
+                    ['main', true],
+                  ],
+                  output: 'index.html',
+                }),
+                tsConfig: join(customRoot, 'tsconfig.base.json'),
               }),
             },
           ]),
@@ -138,13 +177,14 @@ describe('createConfig', () => {
                   media: join(process.cwd(), 'dist', 'browser', 'media'),
                 },
                 index: expect.objectContaining({
-                  input: expect.stringMatching(/\/src\/index\.html$/),
+                  input: join(process.cwd(), 'src/index.html'),
                   insertionOrder: [
                     ['polyfills', true],
                     ['main', true],
                   ],
                   output: 'index.html',
                 }),
+                tsConfig: join(process.cwd(), 'tsconfig.base.json'),
                 sourceMap: {
                   scripts: true,
                   styles: true,

--- a/packages/angular-rspack/src/lib/models/angular-rspack-plugin-options.ts
+++ b/packages/angular-rspack/src/lib/models/angular-rspack-plugin-options.ts
@@ -109,6 +109,7 @@ export interface AngularRspackPluginOptions {
   commonChunk?: boolean;
   devServer?: DevServerOptions;
   extractLicenses?: boolean;
+  root?: string;
 }
 
 export interface NormalizedAngularRspackPluginOptions
@@ -126,5 +127,6 @@ export interface NormalizedAngularRspackPluginOptions
   optimization: boolean | OptimizationOptions;
   outputHashing: OutputHashing;
   outputPath: OutputPath;
+  root: string;
   sourceMap: SourceMap;
 }

--- a/packages/angular-rspack/src/lib/models/normalize-options.ts
+++ b/packages/angular-rspack/src/lib/models/normalize-options.ts
@@ -50,11 +50,11 @@ export function resolveFileReplacements(
   }));
 }
 
-export function getHasServer({
-  server,
-  ssr,
-}: Pick<AngularRspackPluginOptions, 'server' | 'ssr'>): boolean {
-  const root = process.cwd();
+export function getHasServer(
+  root: string,
+  server: string | undefined,
+  ssr: AngularRspackPluginOptions['ssr']
+): boolean {
   return !!(
     server &&
     ssr &&
@@ -116,7 +116,10 @@ export function normalizeOptions(
   validateOptimization(optimization);
   const normalizedOptimization = optimization !== false; // @TODO: Add support for optimization options
 
-  const root = process.cwd();
+  const root = options.root ?? process.cwd();
+  const tsConfig = options.tsConfig
+    ? resolve(root, options.tsConfig)
+    : join(root, 'tsconfig.app.json');
 
   const aot = options.aot ?? true;
   // @TODO: use this once we support granular optimization options
@@ -218,9 +221,9 @@ export function normalizeOptions(
     aot,
     outputHashing: options.outputHashing ?? 'all',
     inlineStyleLanguage: options.inlineStyleLanguage ?? 'css',
-    tsConfig: options.tsConfig ?? join(root, 'tsconfig.app.json'),
+    tsConfig,
     sourceMap: normalizeSourceMap(options.sourceMap),
-    hasServer: getHasServer({ server, ssr: normalizedSsr }),
+    hasServer: getHasServer(root, server, normalizedSsr),
     skipTypeChecking: options.skipTypeChecking ?? false,
     useTsProjectReferences: options.useTsProjectReferences ?? false,
     namedChunks: options.namedChunks ?? false,
@@ -228,6 +231,7 @@ export function normalizeOptions(
     commonChunk: options.commonChunk ?? true,
     devServer: normalizeDevServer(options.devServer),
     extractLicenses: options.extractLicenses ?? true,
+    root,
   };
 }
 

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
@@ -58,7 +58,7 @@ export class AngularRspackPlugin implements RspackPluginInstance {
   }
 
   apply(compiler: Compiler) {
-    const root = compiler.options.context ?? process.cwd();
+    const root = this.#_options.root;
     // Both of these are exclusive to each other - only one of them can be used at a time
     // But they will happen before the compiler is created - so we can use them to set up the parallel compilation once
     compiler.hooks.beforeRun.tapAsync(

--- a/packages/angular-rspack/src/lib/plugins/ng-rspack.ts
+++ b/packages/angular-rspack/src/lib/plugins/ng-rspack.ts
@@ -21,7 +21,7 @@ export class NgRspackPlugin implements RspackPluginInstance {
   }
 
   apply(compiler: Compiler) {
-    const root = compiler.options.context ?? process.cwd();
+    const root = this.pluginOptions.root;
     const isProduction = process.env['NODE_ENV'] === 'production';
     const isDevServer = process.env['WEBPACK_SERVE'];
 


### PR DESCRIPTION
Add `root` option and normalize `tsConfig` to avoid having to provide an absolute path.