### PR TITLE
feat(angular-rspack): add allowedHosts option

### DIFF
--- a/packages/angular-rspack/src/lib/config/create-config.ts
+++ b/packages/angular-rspack/src/lib/config/create-config.ts
@@ -21,7 +21,10 @@ import {
 } from '@nx/angular-rspack-compiler';
 import { getStyleLoaders, getStylesEntry } from './style-config-utils';
 import { getOutputHashFormat } from './helpers';
-import { getProxyConfig } from './dev-server-config-utils';
+import {
+  getAllowedHostsConfig,
+  getProxyConfig,
+} from './dev-server-config-utils';
 import { DevToolsIgnorePlugin } from '../plugins/tools/dev-tools-ignore-plugin';
 
 function configureSourceMap(sourceMap: SourceMap) {
@@ -195,7 +198,10 @@ export async function _createConfig(
         headers: {
           'Access-Control-Allow-Origin': '*',
         },
-        allowedHosts: 'auto',
+        allowedHosts: getAllowedHostsConfig(
+          normalizedOptions.devServer.allowedHosts,
+          normalizedOptions.devServer.disableHostCheck
+        ),
         client: {
           webSocketURL: {
             hostname: normalizedOptions.devServer.host,
@@ -324,7 +330,10 @@ export async function _createConfig(
       headers: {
         'Access-Control-Allow-Origin': '*',
       },
-      allowedHosts: 'auto',
+      allowedHosts: getAllowedHostsConfig(
+        normalizedOptions.devServer.allowedHosts,
+        normalizedOptions.devServer.disableHostCheck
+      ),
       client: {
         webSocketURL: {
           hostname: normalizedOptions.devServer.host,

--- a/packages/angular-rspack/src/lib/config/create-config.unit.test.ts
+++ b/packages/angular-rspack/src/lib/config/create-config.unit.test.ts
@@ -111,10 +111,10 @@ describe('createConfig', () => {
                 polyfills: ['zone.js'],
                 globalScripts: scripts,
                 globalStyles: styles,
-                devServer: {
+                devServer: expect.objectContaining({
                   host: 'localhost',
                   port: 4200,
-                },
+                }),
               }),
             },
           ]),
@@ -136,13 +136,14 @@ describe('createConfig', () => {
       ).resolves.not.toContain([
         expect.objectContaining({
           clearScreen: true,
-          devServer: { allowedHosts: ['localhost'] },
+          devServer: expect.objectContaining({
+            allowedHosts: ['localhost'],
+          }),
         }),
       ]);
       expect(warnSpy).toHaveBeenCalledWith(
         `The following options are not yet supported:
   "clearScreen"
-  "devServer.allowedHosts"
 `
       );
     });

--- a/packages/angular-rspack/src/lib/config/dev-server-config-utils.ts
+++ b/packages/angular-rspack/src/lib/config/dev-server-config-utils.ts
@@ -4,6 +4,20 @@ import { existsSync, promises as fsPromises } from 'node:fs';
 import { extname, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
+export function getAllowedHostsConfig(
+  allowedHosts: string[] | boolean | undefined,
+  disableHostCheck: boolean | undefined
+) {
+  if (disableHostCheck || allowedHosts === true) {
+    return 'all';
+  }
+  if (Array.isArray(allowedHosts) && allowedHosts.length > 0) {
+    return allowedHosts;
+  }
+
+  return undefined;
+}
+
 export async function getProxyConfig(
   root: string,
   proxyConfig: string | undefined

--- a/packages/angular-rspack/src/lib/models/angular-rspack-plugin-options.ts
+++ b/packages/angular-rspack/src/lib/models/angular-rspack-plugin-options.ts
@@ -9,6 +9,14 @@ import type {
 } from './unsupported-options';
 
 export interface DevServerOptions extends DevServerUnsupportedOptions {
+  /**
+   * The hosts that the development server will respond to.
+   */
+  allowedHosts?: string[] | boolean;
+  /**
+   * Don't verify connected clients are part of allowed hosts.
+   */
+  disableHostCheck?: boolean;
   host?: string;
   port?: number;
   proxyConfig?: string;
@@ -17,6 +25,7 @@ export interface DevServerOptions extends DevServerUnsupportedOptions {
   sslKey?: string;
 }
 export interface NormalizedDevServerOptions extends DevServerOptions {
+  allowedHosts: string[] | boolean;
   host: string;
   port: number;
 }

--- a/packages/angular-rspack/src/lib/models/normalize-options.ts
+++ b/packages/angular-rspack/src/lib/models/normalize-options.ts
@@ -301,11 +301,16 @@ function normalizeDevServer(
   const defaultPort = 4200;
 
   if (!devServer) {
-    return { host: defaultHost, port: defaultPort };
+    return {
+      allowedHosts: [],
+      host: defaultHost,
+      port: defaultPort,
+    };
   }
 
   return {
     ...devServer,
+    allowedHosts: devServer.allowedHosts ?? [],
     host: devServer.host ?? defaultHost,
     port: devServer.port ?? defaultPort,
   };

--- a/packages/angular-rspack/src/lib/models/unsupported-options.ts
+++ b/packages/angular-rspack/src/lib/models/unsupported-options.ts
@@ -18,7 +18,6 @@ export type BudgetEntry = {
 };
 
 export interface DevServerUnsupportedOptions {
-  allowedHosts?: string[] | boolean;
   headers?: Record<string, string>;
   open?: boolean;
   liveReload?: boolean;
@@ -98,7 +97,6 @@ export const TOP_LEVEL_OPTIONS_PENDING_SUPPORT = [
 ];
 
 export const DEV_SERVER_OPTIONS_PENDING_SUPPORT = [
-  'allowedHosts',
   'headers',
   'open',
   'liveReload',


### PR DESCRIPTION
## Current Behaviour
In `@nx/angular-rspack` the `allowedHosts` option is always set to `auto`. User provided options are ignored.

## Expected Behaviour
Use `allowedHosts` option to determine the array of hosts the dev server can accept connections from. Aternatively, if set to true, `'all'` is used.
