### PR TITLE
feat(angular-rspack,angular-rsbuild): add preserveSymlinks option

### DIFF
--- a/packages/angular-rsbuild/src/lib/config/create-config.ts
+++ b/packages/angular-rsbuild/src/lib/config/create-config.ts
@@ -141,6 +141,7 @@ export async function _createConfig(
       rspack(config) {
         config.resolve ??= {};
         config.resolve.extensionAlias = {};
+        config.resolve.symlinks = normalizedOptions.preserveSymlinks;
       },
     },
     environments: {

--- a/packages/angular-rsbuild/src/lib/models/plugin-options.ts
+++ b/packages/angular-rsbuild/src/lib/models/plugin-options.ts
@@ -57,6 +57,7 @@ export interface PluginAngularOptions {
         experimentalPlatform?: 'node' | 'neutral';
       };
   polyfills: string[];
+  preserveSymlinks?: boolean;
   assets: string[];
   styles: string[];
   scripts: string[];

--- a/packages/angular-rspack/src/lib/config/create-config.ts
+++ b/packages/angular-rspack/src/lib/config/create-config.ts
@@ -113,12 +113,19 @@ export async function _createConfig(
     },
     resolve: {
       extensions: ['.ts', '.tsx', '.mjs', '.js'],
+      symlinks: !normalizedOptions.preserveSymlinks,
       modules: ['node_modules'],
       mainFields: ['es2020', 'es2015', 'browser', 'module', 'main'],
       conditionNames: ['es2020', 'es2015', '...'],
       tsConfig: {
         configFile: normalizedOptions.tsConfig,
       },
+    },
+    resolveLoader: {
+      symlinks: !normalizedOptions.preserveSymlinks,
+    },
+    watchOptions: {
+      followSymlinks: normalizedOptions.preserveSymlinks,
     },
     module: {
       parser: {

--- a/packages/angular-rspack/src/lib/models/angular-rspack-plugin-options.ts
+++ b/packages/angular-rspack/src/lib/models/angular-rspack-plugin-options.ts
@@ -117,6 +117,10 @@ export interface AngularRspackPluginOptions extends PluginUnsupportedOptions {
     | string
     | (Required<Pick<OutputPath, 'base'>> & Partial<OutputPath>);
   polyfills?: string[];
+  /**
+   * Do not use the real path when resolving modules. If unset then will default to `true` if NodeJS option --preserve-symlinks is set.
+   */
+  preserveSymlinks?: boolean;
   root?: string;
   scripts?: ScriptOrStyleEntry[];
   server?: string;

--- a/packages/angular-rspack/src/lib/models/unsupported-options.ts
+++ b/packages/angular-rspack/src/lib/models/unsupported-options.ts
@@ -51,7 +51,6 @@ export interface PluginUnsupportedOptions {
   watch?: boolean;
   poll?: number;
   deleteOutputPath?: boolean;
-  preserveSymlinks?: boolean;
   subresourceIntegrity?: boolean;
   serviceWorker?: string | false;
   statsJson?: boolean;
@@ -83,7 +82,6 @@ export const TOP_LEVEL_OPTIONS_PENDING_SUPPORT = [
   'watch',
   'poll',
   'deleteOutputPath',
-  'preserveSymlinks',
   'subresourceIntegrity',
   'serviceWorker',
   'statsJson',


### PR DESCRIPTION
## Current Behaviour
The `preserveSymlinks` option is currently a no-op and therefore real files are resolved.


## Expected Behaviour
Support `preserveSymlinks` option and allow the symlinked files to be used
