### PR TITLE
feat(angular-rspack,angular-rsbuild): add deleteOutputPath option

### DIFF
--- a/packages/angular-rsbuild/src/lib/config/create-config.ts
+++ b/packages/angular-rsbuild/src/lib/config/create-config.ts
@@ -174,6 +174,7 @@ export async function _createConfig(
             media: normalizedOptions.outputPath.media,
             assets: normalizedOptions.outputPath.media,
           },
+          cleanDistPath: normalizedOptions.deleteOutputPath,
           copy: normalizedOptions.assets.map((srcPath) => ({
             from: srcPath,
             to: dirname(srcPath),
@@ -203,6 +204,7 @@ export async function _createConfig(
                 target: 'node',
                 polyfill: 'entry',
                 distPath: { root: normalizedOptions.outputPath.server },
+                cleanDistPath: normalizedOptions.deleteOutputPath,
               },
             },
           }

--- a/packages/angular-rsbuild/src/lib/config/helpers.ts
+++ b/packages/angular-rsbuild/src/lib/config/helpers.ts
@@ -1,4 +1,59 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
 import { OutputHashing, HashFormat } from '../models/plugin-options';
+import { readdir, rm } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+
+/**
+ * Delete an output directory, but error out if it's the root of the project.
+ */
+export async function deleteOutputDir(
+  root: string,
+  outputPath: string,
+  emptyOnlyDirectories?: string[]
+): Promise<void> {
+  const resolvedOutputPath = resolve(root, outputPath);
+  if (resolvedOutputPath === root) {
+    throw new Error('Output path MUST not be project root directory!');
+  }
+
+  const directoriesToEmpty = emptyOnlyDirectories
+    ? new Set(
+        emptyOnlyDirectories.map((directory) =>
+          join(resolvedOutputPath, directory)
+        )
+      )
+    : undefined;
+
+  // Avoid removing the actual directory to avoid errors in cases where the output
+  // directory is mounted or symlinked. Instead the contents are removed.
+  let entries;
+  try {
+    entries = await readdir(resolvedOutputPath);
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+      return;
+    }
+    throw error;
+  }
+
+  for (const entry of entries) {
+    const fullEntry = join(resolvedOutputPath, entry);
+
+    // Leave requested directories. This allows symlinks to continue to function.
+    if (directoriesToEmpty?.has(fullEntry)) {
+      await deleteOutputDir(resolvedOutputPath, fullEntry);
+      continue;
+    }
+
+    await rm(fullEntry, { force: true, recursive: true, maxRetries: 3 });
+  }
+}
 
 export function getOutputHashFormat(
   outputHashing: OutputHashing = 'none',

--- a/packages/angular-rsbuild/src/lib/models/normalize-options.ts
+++ b/packages/angular-rsbuild/src/lib/models/normalize-options.ts
@@ -89,6 +89,7 @@ export const DEFAULT_PLUGIN_ANGULAR_OPTIONS: PluginAngularOptions = {
   index: './src/index.html',
   browser: './src/main.ts',
   define: {},
+  deleteOutputPath: true,
   server: undefined,
   ssr: undefined,
   fileReplacements: [],
@@ -123,6 +124,7 @@ export function normalizeOptions(
     optimization,
     devServer,
     define,
+    deleteOutputPath,
     ...restOptions
   } = options;
 
@@ -153,6 +155,7 @@ export function normalizeOptions(
     ...(server != null ? { server } : {}),
     ...(ssr != null ? { ssr: normalizedSsr } : {}),
     ...(define != null ? { define } : {}),
+    ...(deleteOutputPath != null ? { deleteOutputPath } : {}),
     optimization: normalizedOptimization,
     outputPath: normalizeOutputPath(root, options.outputPath),
     sourceMap: normalizeSourceMap(options.sourceMap),

--- a/packages/angular-rsbuild/src/lib/models/plugin-options.ts
+++ b/packages/angular-rsbuild/src/lib/models/plugin-options.ts
@@ -49,6 +49,10 @@ export interface PluginAngularOptions {
    * String values must be put in quotes.
    */
   define?: Record<string, string>;
+  /**
+   * Delete the output path before building.
+   */
+  deleteOutputPath?: boolean;
   server?: string;
   ssr?:
     | boolean

--- a/packages/angular-rspack/src/lib/config/create-config.ts
+++ b/packages/angular-rspack/src/lib/config/create-config.ts
@@ -20,7 +20,7 @@ import {
   TS_ALL_EXT_REGEX,
 } from '@nx/angular-rspack-compiler';
 import { getStyleLoaders, getStylesEntry } from './style-config-utils';
-import { getOutputHashFormat } from './helpers';
+import { deleteOutputDir, getOutputHashFormat } from './helpers';
 import {
   getAllowedHostsConfig,
   getProxyConfig,
@@ -93,6 +93,10 @@ export async function _createConfig(
   const hashFormat = getOutputHashFormat(normalizedOptions.outputHashing);
   const { root } = normalizedOptions;
 
+  if (options.deleteOutputPath) {
+    await deleteOutputDir(root, normalizedOptions.outputPath.base);
+  }
+
   const { sourceMapRules, sourceMapPlugins } = configureSourceMap(
     normalizedOptions.sourceMap
   );
@@ -104,7 +108,7 @@ export async function _createConfig(
     output: {
       uniqueName: 'rspack-angular',
       publicPath: 'auto',
-      clean: true,
+      clean: normalizedOptions.deleteOutputPath,
       crossOriginLoading: false,
       trustedTypes: { policyName: 'angular#bundler' },
       sourceMapFilename: normalizedOptions.sourceMap.scripts
@@ -196,7 +200,7 @@ export async function _createConfig(
       output: {
         ...defaultConfig.output,
         publicPath: '/',
-        clean: true,
+        clean: normalizedOptions.deleteOutputPath,
         path: normalizedOptions.outputPath.server,
         filename: '[name].js',
         chunkFilename: '[name].js',
@@ -396,7 +400,7 @@ export async function _createConfig(
       ...defaultConfig.output,
       hashFunction: isProduction ? 'xxhash64' : undefined,
       publicPath: 'auto',
-      clean: true,
+      clean: normalizedOptions.deleteOutputPath,
       path: normalizedOptions.outputPath.browser,
       cssFilename: `[name]${hashFormat.file}.css`,
       filename: `[name]${hashFormat.chunk}.js`,

--- a/packages/angular-rspack/src/lib/config/helpers.ts
+++ b/packages/angular-rspack/src/lib/config/helpers.ts
@@ -1,4 +1,59 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
 import { OutputHashing, HashFormat } from '../models';
+import { readdir, rm } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+
+/**
+ * Delete an output directory, but error out if it's the root of the project.
+ */
+export async function deleteOutputDir(
+  root: string,
+  outputPath: string,
+  emptyOnlyDirectories?: string[]
+): Promise<void> {
+  const resolvedOutputPath = resolve(root, outputPath);
+  if (resolvedOutputPath === root) {
+    throw new Error('Output path MUST not be project root directory!');
+  }
+
+  const directoriesToEmpty = emptyOnlyDirectories
+    ? new Set(
+        emptyOnlyDirectories.map((directory) =>
+          join(resolvedOutputPath, directory)
+        )
+      )
+    : undefined;
+
+  // Avoid removing the actual directory to avoid errors in cases where the output
+  // directory is mounted or symlinked. Instead the contents are removed.
+  let entries;
+  try {
+    entries = await readdir(resolvedOutputPath);
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+      return;
+    }
+    throw error;
+  }
+
+  for (const entry of entries) {
+    const fullEntry = join(resolvedOutputPath, entry);
+
+    // Leave requested directories. This allows symlinks to continue to function.
+    if (directoriesToEmpty?.has(fullEntry)) {
+      await deleteOutputDir(resolvedOutputPath, fullEntry);
+      continue;
+    }
+
+    await rm(fullEntry, { force: true, recursive: true, maxRetries: 3 });
+  }
+}
 
 export function getOutputHashFormat(
   outputHashing: OutputHashing = 'none',

--- a/packages/angular-rspack/src/lib/models/angular-rspack-plugin-options.ts
+++ b/packages/angular-rspack/src/lib/models/angular-rspack-plugin-options.ts
@@ -105,6 +105,10 @@ export interface AngularRspackPluginOptions extends PluginUnsupportedOptions {
    * String values must be put in quotes.
    */
   define?: Record<string, string>;
+  /**
+   * Delete the output path before building.
+   */
+  deleteOutputPath?: boolean;
   devServer?: DevServerOptions;
   extractLicenses?: boolean;
   fileReplacements?: FileReplacement[];
@@ -146,6 +150,7 @@ export interface NormalizedAngularRspackPluginOptions
   assets: NormalizedAssetElement[];
   browser: string;
   commonChunk: boolean;
+  deleteOutputPath: boolean;
   devServer: NormalizedDevServerOptions;
   extractLicenses: boolean;
   fileReplacements: FileReplacement[];

--- a/packages/angular-rspack/src/lib/models/normalize-options.ts
+++ b/packages/angular-rspack/src/lib/models/normalize-options.ts
@@ -243,6 +243,7 @@ export function normalizeOptions(
     browser: options.browser ?? './src/main.ts',
     commonChunk: options.commonChunk ?? true,
     define: options.define ?? {},
+    deleteOutputPath: options.deleteOutputPath ?? true,
     devServer: normalizeDevServer(options.devServer),
     extractLicenses: options.extractLicenses ?? true,
     fileReplacements: resolveFileReplacements(fileReplacements, root),

--- a/packages/angular-rspack/src/lib/models/unsupported-options.ts
+++ b/packages/angular-rspack/src/lib/models/unsupported-options.ts
@@ -50,7 +50,6 @@ export interface PluginUnsupportedOptions {
   localize?: boolean | string[];
   watch?: boolean;
   poll?: number;
-  deleteOutputPath?: boolean;
   subresourceIntegrity?: boolean;
   serviceWorker?: string | false;
   statsJson?: boolean;
@@ -81,7 +80,6 @@ export const TOP_LEVEL_OPTIONS_PENDING_SUPPORT = [
   'localize',
   'watch',
   'poll',
-  'deleteOutputPath',
   'subresourceIntegrity',
   'serviceWorker',
   'statsJson',


### PR DESCRIPTION
## Current Behaviour
Output paths are always cleaned by default before the next build.

## Expected Behaviour
Add `deleteOutputPath` option to configure if output paths are cleaned before build
