### PR TITLE
feat(angular-rspack,angular-rsbuild): add externalDependencies option

### DIFF
--- a/packages/angular-rsbuild/src/lib/config/create-config.ts
+++ b/packages/angular-rsbuild/src/lib/config/create-config.ts
@@ -205,6 +205,7 @@ export async function _createConfig(
                 polyfill: 'entry',
                 distPath: { root: normalizedOptions.outputPath.server },
                 cleanDistPath: normalizedOptions.deleteOutputPath,
+                externals: normalizedOptions.externalDependencies,
               },
             },
           }

--- a/packages/angular-rsbuild/src/lib/models/normalize-options.ts
+++ b/packages/angular-rsbuild/src/lib/models/normalize-options.ts
@@ -90,6 +90,7 @@ export const DEFAULT_PLUGIN_ANGULAR_OPTIONS: PluginAngularOptions = {
   browser: './src/main.ts',
   define: {},
   deleteOutputPath: true,
+  externalDependencies: [],
   server: undefined,
   ssr: undefined,
   fileReplacements: [],
@@ -125,6 +126,7 @@ export function normalizeOptions(
     devServer,
     define,
     deleteOutputPath,
+    externalDependencies,
     ...restOptions
   } = options;
 
@@ -156,6 +158,7 @@ export function normalizeOptions(
     ...(ssr != null ? { ssr: normalizedSsr } : {}),
     ...(define != null ? { define } : {}),
     ...(deleteOutputPath != null ? { deleteOutputPath } : {}),
+    externalDependencies: externalDependencies ?? [],
     optimization: normalizedOptimization,
     outputPath: normalizeOutputPath(root, options.outputPath),
     sourceMap: normalizeSourceMap(options.sourceMap),

--- a/packages/angular-rsbuild/src/lib/models/plugin-options.ts
+++ b/packages/angular-rsbuild/src/lib/models/plugin-options.ts
@@ -53,6 +53,10 @@ export interface PluginAngularOptions {
    * Delete the output path before building.
    */
   deleteOutputPath?: boolean;
+  /**
+   * Exclude the listed external dependencies from being bundled into the bundle. Instead, the created bundle relies on these dependencies to be available during runtime.
+   */
+  externalDependencies?: string[];
   server?: string;
   ssr?:
     | boolean
@@ -87,6 +91,7 @@ export interface PluginAngularOptions {
 export interface NormalizedPluginAngularOptions extends PluginAngularOptions {
   advancedOptimizations: boolean;
   devServer: DevServerOptions & { port: number };
+  externalDependencies: string[];
   optimization: boolean | OptimizationOptions;
   outputHashing: OutputHashing;
   outputPath: OutputPath;

--- a/packages/angular-rspack/src/lib/config/create-config.ts
+++ b/packages/angular-rspack/src/lib/config/create-config.ts
@@ -253,6 +253,7 @@ export async function _createConfig(
           normalizedOptions.devServer.proxyConfig
         ),
       },
+      externals: normalizedOptions.externalDependencies,
       optimization: {
         chunkIds: normalizedOptions.namedChunks ? 'named' : 'deterministic',
         moduleIds: 'deterministic',

--- a/packages/angular-rspack/src/lib/models/angular-rspack-plugin-options.ts
+++ b/packages/angular-rspack/src/lib/models/angular-rspack-plugin-options.ts
@@ -110,6 +110,10 @@ export interface AngularRspackPluginOptions extends PluginUnsupportedOptions {
    */
   deleteOutputPath?: boolean;
   devServer?: DevServerOptions;
+  /**
+   * Exclude the listed external dependencies from being bundled into the bundle. Instead, the created bundle relies on these dependencies to be available during runtime.
+   */
+  externalDependencies?: string[];
   extractLicenses?: boolean;
   fileReplacements?: FileReplacement[];
   index?: IndexElement;
@@ -152,6 +156,7 @@ export interface NormalizedAngularRspackPluginOptions
   commonChunk: boolean;
   deleteOutputPath: boolean;
   devServer: NormalizedDevServerOptions;
+  externalDependencies: string[];
   extractLicenses: boolean;
   fileReplacements: FileReplacement[];
   globalScripts: GlobalEntry[];

--- a/packages/angular-rspack/src/lib/models/normalize-options.ts
+++ b/packages/angular-rspack/src/lib/models/normalize-options.ts
@@ -245,6 +245,7 @@ export function normalizeOptions(
     define: options.define ?? {},
     deleteOutputPath: options.deleteOutputPath ?? true,
     devServer: normalizeDevServer(options.devServer),
+    externalDependencies: options.externalDependencies ?? [],
     extractLicenses: options.extractLicenses ?? true,
     fileReplacements: resolveFileReplacements(fileReplacements, root),
     globalStyles,

--- a/packages/angular-rspack/src/lib/models/unsupported-options.ts
+++ b/packages/angular-rspack/src/lib/models/unsupported-options.ts
@@ -40,7 +40,6 @@ export interface PluginUnsupportedOptions {
           unsafeEval?: boolean;
         };
   };
-  externalDependencies?: string[];
   clearScreen?: boolean;
   baseHref?: string;
   verbose?: boolean;
@@ -70,7 +69,6 @@ export interface PluginUnsupportedOptions {
 export const TOP_LEVEL_OPTIONS_PENDING_SUPPORT = [
   'deployUrl',
   'security',
-  'externalDependencies',
   'clearScreen',
   'baseHref',
   'verbose',


### PR DESCRIPTION
## Current Behaviour
The `externalDependencies` option is currently not supported and does nothing. This means to define externals for runtime, the user needed to customise the `rspack` and `rsbuild` configs manually.

## Expected Behaviour
Support the `externalDependencies` option
