### PR TITLE
fix(angular-rspack): multiple configurations

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "@nx/devkit": "20.3.0",
     "@types/minimatch": "^5.1.2",
     "ansis": "^3.9.0",
+    "deepmerge": "^4.3.1",
     "eslint-plugin-jest-formatting": "^3.1.0",
     "eslint-plugin-vitest": "^0.5.4",
     "highlight.js": "^11.11.1",

--- a/packages/angular-rspack/package.json
+++ b/packages/angular-rspack/package.json
@@ -49,6 +49,7 @@
     "@babel/core": "7.26.10",
     "@nx/angular-rspack-compiler": "workspace:*",
     "@nx/devkit": "^20.0.0",
+    "deepmerge": "^4.3.1",
     "express": "4.21.1",
     "css-loader": "^7.1.2",
     "jsonc-parser": "^3.3.1",

--- a/packages/angular-rspack/src/lib/config/create-config.unit.test.ts
+++ b/packages/angular-rspack/src/lib/config/create-config.unit.test.ts
@@ -1,4 +1,8 @@
-import { _createConfig, createConfig } from './create-config';
+import {
+  _createConfig,
+  createConfig,
+  handleConfigurations,
+} from './create-config';
 import { beforeEach, expect } from 'vitest';
 import { AngularRspackPluginOptions } from '../models';
 import { join } from 'node:path';
@@ -353,5 +357,46 @@ describe('createConfig', () => {
         );
       }
     );
+
+    it('should successfully merge multiple configurations', () => {
+      const config = handleConfigurations(
+        {
+          options: {
+            ...configBase,
+            i18nMetadata: {
+              locales: {
+                fr: {
+                  translation: 'src/locale/messages.fr.xlf',
+                },
+                de: {
+                  translation: 'src/locale/messages.de.xlf',
+                },
+              },
+              sourceLocale: 'en-GB',
+            },
+          },
+        },
+        {
+          fr: {
+            options: {
+              localize: ['fr'],
+            },
+          },
+          de: {
+            options: {
+              localize: ['de'],
+            },
+          },
+        },
+        ['fr', 'de']
+      );
+      expect(config).toStrictEqual(
+        expect.objectContaining({
+          mergedConfigurationBuildOptions: expect.objectContaining({
+            localize: ['fr', 'de'],
+          }),
+        })
+      );
+    });
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       ansis:
         specifier: ^3.9.0
         version: 3.16.0
+      deepmerge:
+        specifier: ^4.3.1
+        version: 4.3.1
       eslint-plugin-jest-formatting:
         specifier: ^3.1.0
         version: 3.1.0(eslint@9.21.0(jiti@2.4.2))
@@ -523,6 +526,9 @@ importers:
       css-loader:
         specifier: ^7.1.2
         version: 7.1.2(@rspack/core@1.2.6(@swc/helpers@0.5.15))(webpack@5.98.0(@swc/core@1.5.29(@swc/helpers@0.5.15))(esbuild@0.19.12))
+      deepmerge:
+        specifier: ^4.3.1
+        version: 4.3.1
       express:
         specifier: 4.21.1
         version: 4.21.1
@@ -543,7 +549,7 @@ importers:
         version: 1.85.1
       sass-loader:
         specifier: ^16.0.2
-        version: 16.0.5(@rspack/core@1.2.6(@swc/helpers@0.5.15))(sass-embedded@1.85.1)(sass@1.85.1)(webpack@5.98.0(@swc/core@1.5.29(@swc/helpers@0.5.15))(esbuild@0.19.12))
+        version: 16.0.5(@rspack/core@1.2.6(@swc/helpers@0.5.15))(sass-embedded@1.85.1)(sass@1.85.0)(webpack@5.98.0(@swc/core@1.5.29(@swc/helpers@0.5.15))(esbuild@0.19.12))
       source-map-loader:
         specifier: ^5.0.0
         version: 5.0.0(webpack@5.98.0(@swc/core@1.5.29(@swc/helpers@0.5.15))(esbuild@0.19.12))
@@ -20283,6 +20289,15 @@ snapshots:
       sass: 1.83.1
       sass-embedded: 1.85.1
       webpack: 5.97.1(@swc/core@1.5.29(@swc/helpers@0.5.15))(esbuild@0.24.2)
+
+  sass-loader@16.0.5(@rspack/core@1.2.6(@swc/helpers@0.5.15))(sass-embedded@1.85.1)(sass@1.85.0)(webpack@5.98.0(@swc/core@1.5.29(@swc/helpers@0.5.15))(esbuild@0.19.12)):
+    dependencies:
+      neo-async: 2.6.2
+    optionalDependencies:
+      '@rspack/core': 1.2.6(@swc/helpers@0.5.15)
+      sass: 1.85.0
+      sass-embedded: 1.85.1
+      webpack: 5.98.0(@swc/core@1.5.29(@swc/helpers@0.5.15))(esbuild@0.19.12)
 
   sass-loader@16.0.5(@rspack/core@1.2.6(@swc/helpers@0.5.15))(sass-embedded@1.85.1)(sass@1.85.1)(webpack@5.98.0(@swc/core@1.5.29(@swc/helpers@0.5.15))(esbuild@0.19.12)):
     dependencies:


### PR DESCRIPTION
## Current Behaviour
The `NGRS_CONFIG` env var for passing in specific configurations does not support passing multiple configurations.


## Expected Behaviour
The `NGRS_CONFIG` env var should support comma-seperated configurations and `createConfig` should handle it correctly
