### PR TITLE
feat(angular-rspack): add service-worker support

### DIFF
--- a/packages/angular-rspack/src/lib/models/angular-rspack-plugin-options.ts
+++ b/packages/angular-rspack/src/lib/models/angular-rspack-plugin-options.ts
@@ -136,6 +136,10 @@ export interface AngularRspackPluginOptions extends PluginUnsupportedOptions {
    */
   localize?: boolean | string[];
   namedChunks?: boolean;
+  /**
+   * Path to ngsw-config.json.
+   */
+  ngswConfigPath?: string;
   optimization?: boolean | OptimizationOptions;
   outputHashing?: OutputHashing;
   outputPath?:
@@ -149,6 +153,10 @@ export interface AngularRspackPluginOptions extends PluginUnsupportedOptions {
   root?: string;
   scripts?: ScriptOrStyleEntry[];
   server?: string;
+  /**
+   * Generates a service worker config for production builds.
+   */
+  serviceWorker?: boolean;
   skipTypeChecking?: boolean;
   sourceMap?: boolean | Partial<SourceMap>;
   ssr?:

--- a/packages/angular-rspack/src/lib/models/normalize-options.ts
+++ b/packages/angular-rspack/src/lib/models/normalize-options.ts
@@ -259,6 +259,8 @@ export function normalizeOptions(
     outputPath: normalizeOutputPath(root, options.outputPath),
     polyfills: options.polyfills ?? [],
     root,
+    serviceWorker: options.serviceWorker,
+    ngswConfigPath: options.ngswConfigPath,
     server,
     skipTypeChecking: options.skipTypeChecking ?? false,
     sourceMap: normalizeSourceMap(options.sourceMap),

--- a/packages/angular-rspack/src/lib/models/unsupported-options.ts
+++ b/packages/angular-rspack/src/lib/models/unsupported-options.ts
@@ -47,7 +47,6 @@ export interface PluginUnsupportedOptions {
   watch?: boolean;
   poll?: number;
   subresourceIntegrity?: boolean;
-  serviceWorker?: string | false;
   statsJson?: boolean;
   budgets?: BudgetEntry[];
   webWorkerTsConfig?: string;
@@ -73,7 +72,6 @@ export const TOP_LEVEL_OPTIONS_PENDING_SUPPORT = [
   'watch',
   'poll',
   'subresourceIntegrity',
-  'serviceWorker',
   'statsJson',
   'budgets',
   'webWorkerTsConfig',

--- a/packages/angular-rspack/src/lib/utils/get-locale-base-href.ts
+++ b/packages/angular-rspack/src/lib/utils/get-locale-base-href.ts
@@ -1,0 +1,23 @@
+import { I18nOptions } from '../models';
+import { urlJoin } from './url-join';
+
+export function getLocaleBaseHref(
+  i18n: I18nOptions,
+  locale: string,
+  baseHref?: string
+): string | undefined {
+  if (i18n.flatOutput) {
+    return undefined;
+  }
+
+  const localeData = i18n.locales[locale];
+  if (!localeData) {
+    return undefined;
+  }
+
+  const baseHrefSuffix = localeData.baseHref ?? localeData.subPath + '/';
+
+  return baseHrefSuffix !== ''
+    ? urlJoin(baseHref || '', baseHrefSuffix)
+    : undefined;
+}

--- a/packages/angular-rspack/src/lib/utils/url-join.ts
+++ b/packages/angular-rspack/src/lib/utils/url-join.ts
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+export function urlJoin(...parts: string[]): string {
+  const [p, ...rest] = parts;
+
+  // Remove trailing slash from first part
+  // Join all parts with `/`
+  // Dedupe double slashes from path names
+  return p.replace(/\/$/, '') + ('/' + rest.join('/')).replace(/\/\/+/g, '/');
+}


### PR DESCRIPTION
## Current Behaviour
Service Worker is not supported in Angular Rspack.
The `serviceWorker` property is ignored

## Expected Behaviour
Service Workers should be supported
