### PR TITLE
fix(angular-rspack): ensure ngDevMode set correctly by DefinePlugin

### DIFF
--- a/packages/angular-rspack/src/lib/plugins/ng-rspack.ts
+++ b/packages/angular-rspack/src/lib/plugins/ng-rspack.ts
@@ -79,7 +79,8 @@ export class NgRspackPlugin implements RspackPluginInstance {
       new ProgressPlugin().apply(compiler);
     }
     new DefinePlugin({
-      ngDevMode: isProduction ? 'false' : {},
+      // TODO: Replace with ...(this.pluginOptions.optimization.scripts ? { 'ngDevMode': 'false' } : undefined) when Optimization is implemented
+      ...(this.pluginOptions.optimization ? { ngDevMode: 'false' } : {}),
       ngJitMode: this.pluginOptions.aot ? undefined : 'true',
       ngServerMode: this.pluginOptions.hasServer,
       ...(this.pluginOptions.define ?? {}),


### PR DESCRIPTION
## Current Behaviour
When we define `ngDevMode` via `DefinePlugin` we're currently setting it to `{}` in dev.

## Expected Behaviour
It should not be set at all in `DefinePlugin` when in devMode


