### PR TITLE
fix(angular-rspack): mark @angular/localize as optional peer dep

### DIFF
--- a/packages/angular-rspack/package.json
+++ b/packages/angular-rspack/package.json
@@ -68,7 +68,10 @@
     "ws": "^8.18.0"
   },
   "devDependencies": {
-    "@ng-rspack/testing-setup": "workspace:*"
+    "@ng-rspack/testing-setup": "workspace:*",
+    "@code-pushup/models": "^0.63.0",
+    "@code-pushup/utils": "^0.63.0",
+    "jsonc-eslint-parser": "^2.4.0"
   },
   "peerDependencies": {
     "@angular/common": ">=19.0.0 <20.0.0",
@@ -80,6 +83,9 @@
   },
   "peerDependenciesMeta": {
     "tailwindcss": {
+      "optional": true
+    },
+    "@angular/localize": {
       "optional": true
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -611,9 +611,18 @@ importers:
         specifier: ^8.18.0
         version: 8.18.1
     devDependencies:
+      '@code-pushup/models':
+        specifier: ^0.63.0
+        version: 0.63.0
+      '@code-pushup/utils':
+        specifier: ^0.63.0
+        version: 0.63.0
       '@ng-rspack/testing-setup':
         specifier: workspace:*
         version: link:../../testing/setup
+      jsonc-eslint-parser:
+        specifier: ^2.4.0
+        version: 2.4.0
 
   packages/angular-rspack-compiler:
     dependencies:


### PR DESCRIPTION
## Current Behaviour
`@nx/angular-rspack` expects `@angular/localize` to always be present as a defined peer dependency.
This is only the case for i18n projects.

## Expected Behaviour
Mark `@angular/localize` as an optional peer dependency
