### PR TITLE
fix(angular-rspack): handle windows disk drive in loader #53

### DIFF
--- a/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.ts
@@ -32,7 +32,7 @@ export default function loader(
       NG_RSPACK_SYMBOL_NAME
     ]();
 
-    const request = this.resourcePath;
+    const request = this.resourcePath.replace(/^[A-Z]:/, '');
     const normalizedRequest = normalize(request);
 
     const templateUrls = templateUrlsResolver.resolve(


### PR DESCRIPTION
## Current Behaviour
Angular Rspack does not compile correctly on Windows.
It searches the TS File Cache for the transformed app source with an invalid path - the disk drive is stripped from the TS File Cache on entry but not on retrieval.

## Expected Behaviour
Strip the disk drive path from the `resourcePath` in the loader to ensure transformed contents are found correctly.

Fixes #53 
