### PR TITLE
feat(angular-rspack): add support for more devServer options

### DIFF
--- a/packages/angular-rspack/src/lib/config/config-utils/browser-config.ts
+++ b/packages/angular-rspack/src/lib/config/config-utils/browser-config.ts
@@ -1,21 +1,16 @@
-import type { Configuration, DevServer } from '@rspack/core';
-import { resolve } from 'path';
-import { getPolyfillsEntry, toRspackEntries } from './entry-points';
-import {
-  getAllowedHostsConfig,
-  getProxyConfig,
-} from './dev-server-config-utils';
-import { getOptimization } from './optimization-config';
-import { NgRspackPlugin } from '../../plugins/ng-rspack';
-import {
+import { TS_ALL_EXT_REGEX } from '@nx/angular-rspack-compiler';
+import type { Configuration } from '@rspack/core';
+import type {
   HashFormat,
   I18nOptions,
   NormalizedAngularRspackPluginOptions,
 } from '../../models';
-import { TS_ALL_EXT_REGEX } from '@nx/angular-rspack-compiler';
+import { NgRspackPlugin } from '../../plugins/ng-rspack';
+import { getDevServerConfig } from './dev-server-config-utils';
+import { getPolyfillsEntry, toRspackEntries } from './entry-points';
+import { getOptimization } from './optimization-config';
 
 export async function getBrowserConfig(
-  root: string,
   normalizedOptions: NormalizedAngularRspackPluginOptions,
   i18n: I18nOptions,
   hashFormat: HashFormat,
@@ -49,65 +44,7 @@ export async function getBrowserConfig(
         normalizedOptions.root
       ),
     },
-    devServer: {
-      headers: {
-        'Access-Control-Allow-Origin': '*',
-      },
-      allowedHosts: getAllowedHostsConfig(
-        normalizedOptions.devServer.allowedHosts,
-        normalizedOptions.devServer.disableHostCheck
-      ),
-      client: {
-        webSocketURL: {
-          hostname: normalizedOptions.devServer.host,
-          port: normalizedOptions.devServer.port,
-        },
-        overlay: {
-          errors: true,
-          warnings: false,
-          runtimeErrors: true,
-        },
-        reconnect: true,
-      },
-      hot: false,
-      liveReload: true,
-      watchFiles: ['./src/**/*.*', './public/**/*.*'],
-      historyApiFallback: {
-        index: '/index.html',
-        rewrites: [{ from: /^\/$/, to: 'index.html' }],
-      },
-      devMiddleware: {
-        writeToDisk: (file) => !file.includes('.hot-update.'),
-      },
-      host: normalizedOptions.devServer.host,
-      port: normalizedOptions.devServer.port,
-      server: {
-        options:
-          normalizedOptions.devServer.sslKey &&
-          normalizedOptions.devServer.sslCert
-            ? {
-                key: resolve(root, normalizedOptions.devServer.sslKey),
-                cert: resolve(root, normalizedOptions.devServer.sslCert),
-              }
-            : {},
-        type: normalizedOptions.devServer.ssl ? 'https' : 'http',
-      },
-      proxy: await getProxyConfig(
-        root,
-        normalizedOptions.devServer.proxyConfig
-      ),
-      onListening: (devServer) => {
-        if (!devServer) {
-          throw new Error('@rspack/dev-server is not defined');
-        }
-
-        const port =
-          (devServer.server?.address() as { port: number })?.port ??
-          normalizedOptions.devServer.port;
-        console.log('Listening on port:', port);
-      },
-    } as DevServer,
-
+    devServer: await getDevServerConfig(normalizedOptions, 'browser'),
     output: {
       ...defaultConfig.output,
       hashFunction: isProduction ? 'xxhash64' : undefined,

--- a/packages/angular-rspack/src/lib/config/config-utils/common-config.ts
+++ b/packages/angular-rspack/src/lib/config/config-utils/common-config.ts
@@ -13,7 +13,6 @@ import { getCrossOriginLoading } from './helpers';
 import { configureSourceMap } from './sourcemap-utils';
 
 export async function getCommonConfig(
-  root: string,
   normalizedOptions: NormalizedAngularRspackPluginOptions,
   i18n: I18nOptions,
   i18nHash: string | (() => void),
@@ -29,7 +28,7 @@ export async function getCommonConfig(
   );
 
   const defaultConfig: Configuration = {
-    context: root,
+    context: normalizedOptions.root,
     mode: isProduction ? 'production' : 'development',
     devtool: normalizedOptions.sourceMap.scripts ? 'source-map' : undefined,
     output: {

--- a/packages/angular-rspack/src/lib/config/config-utils/dev-server-config-utils.ts
+++ b/packages/angular-rspack/src/lib/config/config-utils/dev-server-config-utils.ts
@@ -42,7 +42,10 @@ export async function getDevServerConfig(
     ),
     devMiddleware: {
       publicPath: servePath,
-      writeToDisk: (file) => !file.includes('.hot-update.'),
+      writeToDisk:
+        platform === 'browser' && options.hasServer
+          ? (file) => !file.includes('.hot-update.')
+          : undefined,
     },
     liveReload: options.devServer.liveReload,
     hot: false,

--- a/packages/angular-rspack/src/lib/config/config-utils/dev-server-config-utils.ts
+++ b/packages/angular-rspack/src/lib/config/config-utils/dev-server-config-utils.ts
@@ -1,11 +1,171 @@
 import type { DevServer } from '@rspack/core';
 import assert from 'node:assert';
 import { existsSync, promises as fsPromises } from 'node:fs';
-import { extname, resolve } from 'node:path';
+import { extname, posix, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
+import type { NormalizedAngularRspackPluginOptions } from '../../models';
+import { getIndexOutputFile } from '../../utils/index-file/get-index-output-file';
 import { loadEsmModule } from '../../utils/misc-helpers';
 
-export function getAllowedHostsConfig(
+export async function getDevServerConfig(
+  options: NormalizedAngularRspackPluginOptions,
+  platform: 'browser' | 'server'
+): Promise<DevServer> {
+  const { root } = options;
+
+  const servePath = buildServePath(options);
+
+  return {
+    host: options.devServer.host,
+    port: options.devServer.port,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      ...options.devServer.headers,
+    },
+    historyApiFallback: {
+      index: posix.join(servePath, getIndexOutputFile(options.index)),
+      disableDotRule: true,
+      htmlAcceptHeaders: ['text/html', 'application/xhtml+xml'],
+      rewrites: [
+        {
+          from: new RegExp(`^(?!${servePath})/.*`),
+          to: (context) => context.parsedUrl.href,
+        },
+      ],
+    },
+    compress: false,
+    static: false,
+    server: getServerConfig(options),
+    allowedHosts: getAllowedHostsConfig(
+      options.devServer.allowedHosts,
+      options.devServer.disableHostCheck
+    ),
+    devMiddleware: {
+      publicPath: servePath,
+      writeToDisk: (file) => !file.includes('.hot-update.'),
+    },
+    liveReload: options.devServer.liveReload,
+    hot: false,
+    proxy: await getProxyConfig(root, options.devServer.proxyConfig),
+    ...getWebSocketSettings(options, servePath),
+    watchFiles: ['./src/**/*.*', './public/**/*.*'],
+    onListening:
+      platform === 'browser'
+        ? (devServer) => {
+            if (!devServer) {
+              throw new Error('@rspack/dev-server is not defined');
+            }
+
+            const port =
+              (devServer.server?.address() as { port: number })?.port ??
+              options.devServer.port;
+            console.log('Listening on port:', port);
+          }
+        : undefined,
+  };
+}
+
+/**
+ * Resolve and build a URL _path_ that will be the root of the server. This resolves base href and
+ * deploy URL from the browser options and returns a path from the root.
+ */
+function buildServePath(options: NormalizedAngularRspackPluginOptions): string {
+  let servePath = options.devServer.servePath;
+
+  if (servePath === undefined) {
+    const defaultPath = findDefaultServePath(
+      options.baseHref,
+      options.deployUrl
+    );
+    if (defaultPath == null) {
+      console.warn(
+        `Warning: --deploy-url and/or --base-href contain unsupported values for ng serve. Default serve path of '/' used. Use --serve-path to override.`
+      );
+    }
+    servePath = defaultPath || '';
+  }
+
+  if (servePath.endsWith('/')) {
+    servePath = servePath.slice(0, -1);
+  }
+
+  if (!servePath.startsWith('/')) {
+    servePath = `/${servePath}`;
+  }
+
+  return servePath;
+}
+
+/**
+ * Find the default server path. We don't want to expose baseHref and deployUrl as arguments, only
+ * the browser options where needed.
+ */
+function findDefaultServePath(
+  baseHref?: string,
+  deployUrl?: string
+): string | null {
+  if (!baseHref && !deployUrl) {
+    return '';
+  }
+
+  if (
+    /^(\w+:)?\/\//.test(baseHref || '') ||
+    /^(\w+:)?\/\//.test(deployUrl || '')
+  ) {
+    // If baseHref or deployUrl is absolute, unsupported by ng serve
+    return null;
+  }
+
+  // normalize baseHref
+  // for ng serve the starting base is always `/` so a relative
+  // and root relative value are identical
+  const baseHrefParts = (baseHref || '')
+    .split('/')
+    .filter((part) => part !== '');
+  if (baseHref && !baseHref.endsWith('/')) {
+    baseHrefParts.pop();
+  }
+  const normalizedBaseHref =
+    baseHrefParts.length === 0 ? '/' : `/${baseHrefParts.join('/')}/`;
+
+  if (deployUrl && deployUrl[0] === '/') {
+    if (baseHref && baseHref[0] === '/' && normalizedBaseHref !== deployUrl) {
+      // If baseHref and deployUrl are root relative and not equivalent, unsupported by ng serve
+      return null;
+    }
+
+    return deployUrl;
+  }
+
+  // Join together baseHref and deployUrl
+  return `${normalizedBaseHref}${deployUrl || ''}`;
+}
+
+function getServerConfig(
+  options: NormalizedAngularRspackPluginOptions
+): DevServer['server'] {
+  const {
+    root,
+    devServer: { ssl, sslCert, sslKey },
+  } = options;
+
+  if (!ssl) {
+    return 'http';
+  }
+
+  return {
+    type: 'https',
+    options:
+      sslCert && sslKey
+        ? {
+            key: resolve(root, sslKey),
+            cert: resolve(root, sslCert),
+          }
+        : undefined,
+  };
+}
+
+function getAllowedHostsConfig(
   allowedHosts: string[] | boolean | undefined,
   disableHostCheck: boolean | undefined
 ) {
@@ -19,7 +179,7 @@ export function getAllowedHostsConfig(
   return undefined;
 }
 
-export async function getProxyConfig(
+async function getProxyConfig(
   root: string,
   proxyConfig: string | undefined
 ): Promise<DevServer['proxy'] | undefined> {
@@ -97,6 +257,52 @@ export async function getProxyConfig(
   }
 
   return normalizeProxyConfiguration(proxyConfiguration);
+}
+
+function getWebSocketSettings(
+  options: NormalizedAngularRspackPluginOptions,
+  servePath: string
+): {
+  webSocketServer?: DevServer['webSocketServer'];
+  client?: DevServer['client'];
+} {
+  const { hmr, liveReload } = options.devServer;
+  if (!hmr && !liveReload) {
+    return { client: undefined, webSocketServer: false };
+  }
+
+  const webSocketPath = posix.join(servePath, 'ng-cli-ws');
+
+  return {
+    webSocketServer: {
+      options: { path: webSocketPath },
+    },
+    client: {
+      logging: 'info',
+      webSocketURL: getPublicHostOptions(options, webSocketPath),
+      overlay: {
+        errors: true,
+        warnings: false,
+        runtimeErrors: false,
+      },
+    },
+  };
+}
+
+function getPublicHostOptions(
+  options: NormalizedAngularRspackPluginOptions,
+  webSocketPath: string
+): string {
+  let publicHost = options.devServer.publicHost;
+
+  if (publicHost) {
+    const hostWithProtocol = !/^\w+:\/\//.test(publicHost)
+      ? `https://${publicHost}`
+      : publicHost;
+    publicHost = new URL(hostWithProtocol).host;
+  }
+
+  return `auto://${publicHost || '0.0.0.0:0'}${webSocketPath}`;
 }
 
 function getJsonErrorLineColumn(offset: number, content: string) {

--- a/packages/angular-rspack/src/lib/config/config-utils/server-config.ts
+++ b/packages/angular-rspack/src/lib/config/config-utils/server-config.ts
@@ -1,25 +1,23 @@
-import { Configuration, ContextReplacementPlugin } from '@rspack/core';
+import { TS_ALL_EXT_REGEX } from '@nx/angular-rspack-compiler';
+import { type Configuration, ContextReplacementPlugin } from '@rspack/core';
 import { resolve } from 'path';
-import {
-  getAllowedHostsConfig,
-  getProxyConfig,
-} from './dev-server-config-utils';
-import { getOptimization } from './optimization-config';
-import { isPackageInstalled } from '../../utils/misc-helpers';
-import { NgRspackPlugin } from '../../plugins/ng-rspack';
-import {
+import type {
   I18nOptions,
   NormalizedAngularRspackPluginOptions,
 } from '../../models';
-import { TS_ALL_EXT_REGEX } from '@nx/angular-rspack-compiler';
+import { NgRspackPlugin } from '../../plugins/ng-rspack';
 import { PrerenderPlugin } from '../../plugins/prerender-plugin';
+import { isPackageInstalled } from '../../utils/misc-helpers';
+import { getDevServerConfig } from './dev-server-config-utils';
+import { getOptimization } from './optimization-config';
 
 export async function getServerConfig(
-  root: string,
   normalizedOptions: NormalizedAngularRspackPluginOptions,
   i18n: I18nOptions,
   defaultConfig: Configuration
 ): Promise<Configuration> {
+  const { root } = normalizedOptions;
+
   return {
     ...defaultConfig,
     name: 'server',
@@ -44,54 +42,7 @@ export async function getServerConfig(
       chunkFilename: '[name].js',
       library: { type: 'commonjs' },
     },
-    devServer: {
-      headers: {
-        'Access-Control-Allow-Origin': '*',
-      },
-      allowedHosts: getAllowedHostsConfig(
-        normalizedOptions.devServer.allowedHosts,
-        normalizedOptions.devServer.disableHostCheck
-      ),
-      client: {
-        webSocketURL: {
-          hostname: normalizedOptions.devServer.host,
-          port: normalizedOptions.devServer.port,
-        },
-        overlay: {
-          errors: true,
-          warnings: false,
-          runtimeErrors: true,
-        },
-        reconnect: true,
-      },
-      host: normalizedOptions.devServer.host,
-      port: normalizedOptions.devServer.port,
-      hot: false,
-      liveReload: true,
-      watchFiles: ['./src/**/*.*', './public/**/*.*'],
-      historyApiFallback: {
-        index: '/index.html',
-        rewrites: [{ from: /^\/$/, to: 'index.html' }],
-      },
-      devMiddleware: {
-        writeToDisk: (file) => !file.includes('.hot-update.'),
-      },
-      server: {
-        options:
-          normalizedOptions.devServer.sslKey &&
-          normalizedOptions.devServer.sslCert
-            ? {
-                key: resolve(root, normalizedOptions.devServer.sslKey),
-                cert: resolve(root, normalizedOptions.devServer.sslCert),
-              }
-            : {},
-        type: normalizedOptions.devServer.ssl ? 'https' : 'http',
-      },
-      proxy: await getProxyConfig(
-        root,
-        normalizedOptions.devServer.proxyConfig
-      ),
-    },
+    devServer: await getDevServerConfig(normalizedOptions, 'server'),
     externals: normalizedOptions.externalDependencies,
     optimization: getOptimization(normalizedOptions, 'server'),
     module: {

--- a/packages/angular-rspack/src/lib/config/create-config.ts
+++ b/packages/angular-rspack/src/lib/config/create-config.ts
@@ -50,14 +50,15 @@ export async function _createConfig(
     options
   );
   const hashFormat = getOutputHashFormat(normalizedOptions.outputHashing);
-  const { root } = normalizedOptions;
 
   if (options.deleteOutputPath) {
-    await deleteOutputDir(root, normalizedOptions.outputPath.base);
+    await deleteOutputDir(
+      normalizedOptions.root,
+      normalizedOptions.outputPath.base
+    );
   }
 
   const defaultConfig = await getCommonConfig(
-    root,
     normalizedOptions,
     i18n,
     i18nHash,
@@ -67,7 +68,6 @@ export async function _createConfig(
   const configs: Configuration[] = [];
   if (normalizedOptions.hasServer) {
     const serverConfig: Configuration = await getServerConfig(
-      root,
       normalizedOptions,
       i18n,
       defaultConfig
@@ -80,7 +80,6 @@ export async function _createConfig(
   }
 
   const browserConfig: Configuration = await getBrowserConfig(
-    root,
     normalizedOptions,
     i18n,
     hashFormat,

--- a/packages/angular-rspack/src/lib/config/create-config.unit.test.ts
+++ b/packages/angular-rspack/src/lib/config/create-config.unit.test.ts
@@ -292,11 +292,6 @@ describe('createConfig', () => {
         expect.objectContaining({
           devServer: expect.objectContaining({
             port: 8080,
-            client: expect.objectContaining({
-              webSocketURL: expect.objectContaining({
-                port: 8080,
-              }),
-            }),
           }),
         }),
       ]);
@@ -315,9 +310,7 @@ describe('createConfig', () => {
           devServer: expect.objectContaining({
             host: '0.0.0.0',
             client: expect.objectContaining({
-              webSocketURL: expect.objectContaining({
-                hostname: '0.0.0.0',
-              }),
+              webSocketURL: 'auto://0.0.0.0:0/ng-cli-ws',
             }),
           }),
         }),

--- a/packages/angular-rspack/src/lib/models/angular-rspack-plugin-options.ts
+++ b/packages/angular-rspack/src/lib/models/angular-rspack-plugin-options.ts
@@ -18,9 +18,28 @@ export interface DevServerOptions extends DevServerUnsupportedOptions {
    * Don't verify connected clients are part of allowed hosts.
    */
   disableHostCheck?: boolean;
+  /**
+   * Custom HTTP headers to be added to all responses.
+   */
+  headers?: Record<string, string>;
   host?: string;
+  /**
+   * Whether to reload the page on change, using live-reload.
+   * @default true
+   */
+  liveReload?: boolean;
   port?: number;
   proxyConfig?: string;
+  /**
+   * The URL that the browser client (or live-reload client, if enabled) should
+   * use to connect to the development server. Use for a complex dev server setup,
+   * such as one with reverse proxies.
+   */
+  publicHost?: string;
+  /**
+   * The pathname where the application will be served.
+   */
+  servePath?: string;
   ssl?: boolean;
   sslCert?: string;
   sslKey?: string;
@@ -29,6 +48,7 @@ export interface DevServerOptions extends DevServerUnsupportedOptions {
 export interface NormalizedDevServerOptions extends DevServerOptions {
   allowedHosts: string[] | boolean;
   host: string;
+  liveReload: boolean;
   port: number;
 }
 
@@ -83,10 +103,9 @@ export type IndexExpandedDefinition = {
 export type IndexElement = IndexExpandedDefinition | string | false;
 export type IndexHtmlTransform = (content: string) => Promise<string>;
 export type NormalizedIndexElement =
-  | (IndexExpandedDefinition & {
+  | IndexExpandedDefinition & {
       transformer: IndexHtmlTransform | undefined;
-    })
-  | false;
+    };
 
 export interface SourceMap {
   scripts: boolean;
@@ -233,9 +252,9 @@ export interface NormalizedAngularRspackPluginOptions
   fileReplacements: FileReplacement[];
   globalScripts: GlobalEntry[];
   globalStyles: GlobalEntry[];
-  index: NormalizedIndexElement | undefined;
-  inlineStyleLanguage: InlineStyleLanguage;
   hasServer: boolean;
+  index: NormalizedIndexElement;
+  inlineStyleLanguage: InlineStyleLanguage;
   namedChunks: boolean;
   optimization: boolean | OptimizationOptions;
   outputHashing: OutputHashing;

--- a/packages/angular-rspack/src/lib/models/unsupported-options.ts
+++ b/packages/angular-rspack/src/lib/models/unsupported-options.ts
@@ -18,10 +18,7 @@ export type BudgetEntry = {
 };
 
 export interface DevServerUnsupportedOptions {
-  headers?: Record<string, string>;
   open?: boolean;
-  liveReload?: boolean;
-  servePath?: string;
   hmr?: boolean;
   inspect?: string | boolean;
   prebundle?:
@@ -66,10 +63,7 @@ export const TOP_LEVEL_OPTIONS_PENDING_SUPPORT = [
 ];
 
 export const DEV_SERVER_OPTIONS_PENDING_SUPPORT = [
-  'headers',
   'open',
-  'liveReload',
-  'servePath',
   'hmr',
   'inspect',
   'prebundle',


### PR DESCRIPTION
Add support for the following dev-server options:

- `headers`
- `liveReload`
- `publicHost`
- `servePath`