### PR TITLE
fix(angular-rspack): update the minimum supported version of `@rspack/core`

### DIFF
--- a/packages/angular-rspack/package.json
+++ b/packages/angular-rspack/package.json
@@ -86,7 +86,7 @@
     "@angular/platform-server": ">=19.0.0 <20.0.0",
     "zone.js": ">=0.14.0 <0.16.0",
     "@angular/ssr": ">=19.0.0 <20.0.0",
-    "@rspack/core": ">=1.0.5 <2.0.0",
+    "@rspack/core": ">=1.3.5 <2.0.0",
     "tailwindcss": "^2.0.0 || ^3.0.0 || ^4.0.0"
   },
   "peerDependenciesMeta": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -578,7 +578,7 @@ importers:
         specifier: 21.0.0-beta.8
         version: 21.0.0-beta.8(nx@21.0.0-beta.12(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.15))(@swc/types@0.1.19)(typescript@5.7.3))(@swc/core@1.5.29(@swc/helpers@0.5.15)))
       '@rspack/core':
-        specifier: '>=1.0.5 <2.0.0'
+        specifier: '>=1.3.5 <2.0.0'
         version: 1.3.7(@swc/helpers@0.5.15)
       autoprefixer:
         specifier: 10.4.21


### PR DESCRIPTION
Update the minimum supported version of `@rspack/core` package to **1.3.5**. This is required to be able to use resolver restrictions as Regex, which was only added in that version (https://github.com/web-infra-dev/rspack/commit/ebef5d0aff42026cbe2635721365e5cc87eed888).