### PR TITLE
feat(angular-rspack,angular-rspack-compiler): reuse existing compilation if exists

### DIFF
--- a/e2e/fixtures/rspack-csr-css/src/app/app.component.css
+++ b/e2e/fixtures/rspack-csr-css/src/app/app.component.css
@@ -1,0 +1,3 @@
+.nx-angular-rspack {
+  color: green;
+}

--- a/e2e/fixtures/rspack-csr-css/src/app/app.component.html
+++ b/e2e/fixtures/rspack-csr-css/src/app/app.component.html
@@ -1,6 +1,7 @@
 <p>&#64;nx/angular-rspack v{{ nxAngularRspackVersion }}</p>
 <p>{{ greeting$ | async }}</p>
 <p class="icon-github">&nbsp;</p>
+<p class="nx-angular-rspack">Nx Angular Rspack CSS Testing</p>
 <app-scss-inline-test></app-scss-inline-test>
 <app-nx-welcome></app-nx-welcome>
 <router-outlet></router-outlet>

--- a/e2e/fixtures/rspack-csr-scss/src/app/app.component.html
+++ b/e2e/fixtures/rspack-csr-scss/src/app/app.component.html
@@ -1,2 +1,3 @@
 <h1>Hello world!</h1>
+<p>component scss test</p>
 <router-outlet></router-outlet>

--- a/e2e/fixtures/rspack-csr-scss/src/app/app.component.scss
+++ b/e2e/fixtures/rspack-csr-scss/src/app/app.component.scss
@@ -1,0 +1,4 @@
+$primary-color: #00f;
+p {
+  color: $primary-color;
+}

--- a/packages/angular-rsbuild/src/lib/plugin/plugin-hoisted-js-transformer.ts
+++ b/packages/angular-rsbuild/src/lib/plugin/plugin-hoisted-js-transformer.ts
@@ -1,11 +1,11 @@
 import { logger, RsbuildPlugin } from '@rsbuild/core';
 import {
-  buildAndAnalyzeWithParallelCompilation,
+  buildAndAnalyze,
   JavaScriptTransformer,
   DiagnosticModes,
   JS_ALL_EXT_REGEX,
   maxWorkers,
-  setupCompilationWithParallelCompilation,
+  setupCompilationWithAngularCompilation,
   PartialMessage,
 } from '@nx/angular-rspack-compiler';
 import type { NormalizedPluginAngularOptions } from '../models/plugin-options';
@@ -51,14 +51,14 @@ export const pluginHoistedJsTransformer = (
     });
 
     api.onBeforeEnvironmentCompile(async () => {
-      const parallelCompilation = await setupCompilationWithParallelCompilation(
+      const parallelCompilation = await setupCompilationWithAngularCompilation(
         config,
         {
           ...options,
           root: options.root,
         }
       );
-      await buildAndAnalyzeWithParallelCompilation(
+      await buildAndAnalyze(
         parallelCompilation,
         typescriptFileCache,
         javascriptTransformer
@@ -70,7 +70,6 @@ export const pluginHoistedJsTransformer = (
         typeCheckResults.errors = errors;
         typeCheckResults.warnings = warnings;
       }
-      await parallelCompilation.close();
     });
 
     api.onAfterBuild(() => {

--- a/packages/angular-rspack-compiler/patch/patch-angular-build.js
+++ b/packages/angular-rspack-compiler/patch/patch-angular-build.js
@@ -16,6 +16,13 @@ function main() {
     './src/tools/angular/compilation/parallel-compilation'
   ] = './src/tools/angular/compilation/parallel-compilation.js';
   fileContentsJson.exports[
+    './src/tools/angular/compilation/angular-compilation'
+  ] = './src/tools/angular/compilation/angular-compilation.js';
+  fileContentsJson.exports['./src/tools/angular/compilation/jit-compilation'] =
+    './src/tools/angular/compilation/jit-compilation.js';
+  fileContentsJson.exports['./src/tools/angular/compilation/aot-compilation'] =
+    './src/tools/angular/compilation/aot-compilation.js';
+  fileContentsJson.exports[
     './src/tools/esbuild/angular/component-stylesheets'
   ] = './src/tools/esbuild/angular/component-stylesheets.js';
 

--- a/packages/angular-rspack-compiler/src/compilation/build-and-analyze.ts
+++ b/packages/angular-rspack-compiler/src/compilation/build-and-analyze.ts
@@ -1,16 +1,16 @@
-import { ParallelCompilation } from '@angular/build/src/tools/angular/compilation/parallel-compilation';
 import { JavaScriptTransformer } from '@angular/build/src/tools/esbuild/javascript-transformer';
 import { normalize } from 'path';
+import { AngularCompilation } from '../models';
 
-export async function buildAndAnalyzeWithParallelCompilation(
-  parallelCompilation: ParallelCompilation,
+export async function buildAndAnalyze(
+  angularCompilation: AngularCompilation,
   typescriptFileCache: Map<string, string | Uint8Array>,
   javascriptTransformer: JavaScriptTransformer
 ) {
   for (const {
     filename,
     contents,
-  } of await parallelCompilation.emitAffectedFiles()) {
+  } of await angularCompilation.emitAffectedFiles()) {
     const normalizedFilename = normalize(filename.replace(/^[A-Z]:/, ''));
     await javascriptTransformer
       .transformData(normalizedFilename, contents, true, false)

--- a/packages/angular-rspack-compiler/src/compilation/index.ts
+++ b/packages/angular-rspack-compiler/src/compilation/index.ts
@@ -1,4 +1,4 @@
 export * from './augments';
 export * from './build-and-analyze';
 export * from './setup-compilation';
-export * from './setup-with-paralell-compilation';
+export * from './setup-with-angular-compilation';

--- a/packages/angular-rspack-compiler/src/compilation/setup-compilation.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-compilation.ts
@@ -1,7 +1,5 @@
 import { RsbuildConfig } from '@rsbuild/core';
 import * as ts from 'typescript';
-import { compileString } from 'sass-embedded';
-import { augmentHostWithResources } from './augments';
 import { InlineStyleLanguage, FileReplacement } from '../models';
 import { loadCompilerCli } from '../utils';
 import { ComponentStylesheetBundler } from '@angular/build/src/tools/esbuild/angular/component-stylesheets';
@@ -38,8 +36,6 @@ export async function setupCompilation(
   config: Pick<RsbuildConfig, 'mode' | 'source'>,
   options: SetupCompilationOptions
 ) {
-  const isProd = config.mode === 'production';
-
   const { readConfiguration } = await loadCompilerCli();
   const { options: tsCompilerOptions, rootNames } = readConfiguration(
     config.source?.tsconfigPath ?? options.tsConfig,
@@ -56,7 +52,6 @@ export async function setupCompilation(
   );
 
   const compilerOptions = tsCompilerOptions;
-  const host = ts.createIncrementalCompilerHost(compilerOptions);
 
   const componentStylesheetBundler = new ComponentStylesheetBundler(
     {
@@ -81,17 +76,9 @@ export async function setupCompilation(
     false
   );
 
-  if (options.aot) {
-    augmentHostWithResources(host, (code) => compileString(code).css, {
-      inlineStylesExtension: options.inlineStyleLanguage,
-      isProd,
-    });
-  }
-
   return {
     rootNames,
     compilerOptions,
-    host,
     componentStylesheetBundler,
   };
 }

--- a/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.ts
@@ -1,22 +1,30 @@
 import type { RsbuildConfig } from '@rsbuild/core';
-import { ParallelCompilation } from '@angular/build/src/tools/angular/compilation/parallel-compilation';
+import {
+  AotCompilation,
+  JitCompilation,
+  AngularCompilation,
+  SourceFileCache,
+} from '../models';
 import {
   setupCompilation,
   styleTransform,
   SetupCompilationOptions,
 } from './setup-compilation';
 
-export async function setupCompilationWithParallelCompilation(
+export async function setupCompilationWithAngularCompilation(
   config: Pick<RsbuildConfig, 'source'>,
   options: SetupCompilationOptions,
-  parallelCompilation?: ParallelCompilation
+  sourceFileCache?: SourceFileCache,
+  angularCompilation?: AngularCompilation,
+  modifiedFiles?: Set<string>
 ) {
   const { rootNames, compilerOptions, componentStylesheetBundler } =
     await setupCompilation(config, options);
-  parallelCompilation ??= new ParallelCompilation(
-    !options.aot,
-    options.hasServer === false
-  );
+  angularCompilation ??= options.aot
+    ? new AotCompilation(options.hasServer === false)
+    : new JitCompilation(options.hasServer === false);
+  modifiedFiles ??= new Set(rootNames);
+
   const fileReplacements: Record<string, string> =
     options.fileReplacements.reduce((r, f) => {
       r[f.replace] = f.with;
@@ -24,12 +32,12 @@ export async function setupCompilationWithParallelCompilation(
     }, {});
 
   try {
-    await parallelCompilation.initialize(
+    const { referencedFiles } = await angularCompilation.initialize(
       config.source?.tsconfigPath ?? options.tsConfig,
       {
-        ...compilerOptions,
+        sourceFileCache,
         fileReplacements,
-        modifiedFiles: new Set(rootNames),
+        modifiedFiles,
         transformStylesheet: styleTransform(componentStylesheetBundler),
         processWebWorker(workerFile: string) {
           return workerFile;
@@ -37,8 +45,11 @@ export async function setupCompilationWithParallelCompilation(
       },
       () => compilerOptions
     );
+    if (sourceFileCache) {
+      sourceFileCache.referencedFiles = referencedFiles;
+    }
   } catch (e) {
     console.error('Failed to initialize Angular Compilation', e);
   }
-  return parallelCompilation;
+  return angularCompilation;
 }

--- a/packages/angular-rspack-compiler/src/compilation/setup-with-paralell-compilation.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-with-paralell-compilation.ts
@@ -8,11 +8,12 @@ import {
 
 export async function setupCompilationWithParallelCompilation(
   config: Pick<RsbuildConfig, 'source'>,
-  options: SetupCompilationOptions
+  options: SetupCompilationOptions,
+  parallelCompilation?: ParallelCompilation
 ) {
   const { rootNames, compilerOptions, componentStylesheetBundler } =
     await setupCompilation(config, options);
-  const parallelCompilation = new ParallelCompilation(
+  parallelCompilation ??= new ParallelCompilation(
     !options.aot,
     options.hasServer === false
   );

--- a/packages/angular-rspack-compiler/src/models/index.ts
+++ b/packages/angular-rspack-compiler/src/models/index.ts
@@ -1,6 +1,18 @@
 import { JavaScriptTransformer } from '@angular/build/src/tools/esbuild/javascript-transformer';
 import { ParallelCompilation } from '@angular/build/src/tools/angular/compilation/parallel-compilation';
-export { ParallelCompilation, JavaScriptTransformer };
+import { AotCompilation } from '@angular/build/src/tools/angular/compilation/aot-compilation';
+import { JitCompilation } from '@angular/build/src/tools/angular/compilation/jit-compilation';
+import { AngularCompilation } from '@angular/build/src/tools/angular/compilation/angular-compilation';
+import { SourceFileCache } from '@angular/build/private';
+
+export {
+  ParallelCompilation,
+  JavaScriptTransformer,
+  SourceFileCache,
+  AotCompilation,
+  JitCompilation,
+  AngularCompilation,
+};
 
 export * from './inline-style-language';
 export * from './file-replacement';
@@ -13,6 +25,7 @@ export enum DiagnosticModes {
   Semantic = 1 << 2,
   All = Option | Syntactic | Semantic,
 }
+
 export interface Location {
   file: string;
   namespace: string;
@@ -22,10 +35,12 @@ export interface Location {
   lineText: string;
   suggestion: string;
 }
+
 export interface PartialNote {
   text?: string;
   location?: Partial<Location> | null;
 }
+
 export interface PartialMessage {
   id?: string;
   pluginName?: string;

--- a/packages/angular-rspack/src/lib/models/augmented-compilation.ts
+++ b/packages/angular-rspack/src/lib/models/augmented-compilation.ts
@@ -1,12 +1,15 @@
 import type { Compilation } from '@rspack/core';
-import type { JavaScriptTransformer } from '@nx/angular-rspack-compiler';
+import type {
+  JavaScriptTransformer,
+  SourceFileCache,
+} from '@nx/angular-rspack-compiler';
 import { I18nOptions } from './i18n';
 
 export const NG_RSPACK_SYMBOL_NAME = 'NG_RSPACK_BUILD';
 
 export type NG_RSPACK_COMPILATION_STATE = {
   javascriptTransformer: JavaScriptTransformer;
-  typescriptFileCache: Map<string, string | Buffer>;
+  typescriptFileCache: SourceFileCache['typeScriptFileCache'];
   i18n?: I18nOptions;
 };
 export type NgRspackCompilation = Compilation & {

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
@@ -293,7 +293,8 @@ export class AngularRspackPlugin implements RspackPluginInstance {
         fileReplacements: this.#_options.fileReplacements,
         useTsProjectReferences: this.#_options.useTsProjectReferences,
         hasServer: this.#_options.hasServer,
-      }
+      },
+      this.#angularCompilation
     );
   }
 }

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
@@ -1,10 +1,12 @@
 import { augmentAppWithServiceWorker } from '@angular/build/private';
 import {
-  buildAndAnalyzeWithParallelCompilation,
+  buildAndAnalyze,
   DiagnosticModes,
   JavaScriptTransformer,
+  SourceFileCache,
   maxWorkers,
-  setupCompilationWithParallelCompilation,
+  setupCompilationWithAngularCompilation,
+  AngularCompilation,
 } from '@nx/angular-rspack-compiler';
 import { workspaceRoot } from '@nx/devkit';
 import {
@@ -23,22 +25,17 @@ import {
 import { getLocaleBaseHref } from '../utils/get-locale-base-href';
 
 const PLUGIN_NAME = 'AngularRspackPlugin';
-type Awaited<T> = T extends Promise<infer U> ? U : T;
-type ResolvedJavascriptTransformer = Parameters<
-  typeof buildAndAnalyzeWithParallelCompilation
->[2];
+type ResolvedJavascriptTransformer = Parameters<typeof buildAndAnalyze>[2];
 
 export class AngularRspackPlugin implements RspackPluginInstance {
   #_options: NormalizedAngularRspackPluginOptions;
   #i18n: I18nOptions | undefined;
-  #typescriptFileCache: Map<string, string>;
+  #sourceFileCache: SourceFileCache;
   #javascriptTransformer: ResolvedJavascriptTransformer;
   // This will be defined in the apply method correctly
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-expect-error
-  #angularCompilation: Awaited<
-    ReturnType<typeof setupCompilationWithParallelCompilation>
-  >;
+  #angularCompilation: AngularCompilation;
 
   constructor(
     options: NormalizedAngularRspackPluginOptions,
@@ -46,7 +43,7 @@ export class AngularRspackPlugin implements RspackPluginInstance {
   ) {
     this.#_options = options;
     this.#i18n = i18nOptions;
-    this.#typescriptFileCache = new Map<string, string>();
+    this.#sourceFileCache = new SourceFileCache();
     this.#javascriptTransformer = new JavaScriptTransformer(
       {
         /**
@@ -77,9 +74,9 @@ export class AngularRspackPlugin implements RspackPluginInstance {
         compiler.hooks.beforeCompile.tapAsync(
           PLUGIN_NAME,
           async (params, callback) => {
-            await buildAndAnalyzeWithParallelCompilation(
+            await buildAndAnalyze(
               this.#angularCompilation,
-              this.#typescriptFileCache,
+              this.#sourceFileCache.typeScriptFileCache,
               this.#javascriptTransformer
             );
             callback();
@@ -105,15 +102,21 @@ export class AngularRspackPlugin implements RspackPluginInstance {
                 ?.modifiedFiles
                 ? new Set(compiler.watching.compiler.modifiedFiles)
                 : new Set<string>();
+
+              if (this.#angularCompilation) {
+                this.#sourceFileCache.invalidate(watchingModifiedFiles);
+              }
               await this.setupCompilation(
                 root,
-                compiler.options.resolve.tsConfig
+                compiler.options.resolve.tsConfig,
+                watchingModifiedFiles.size > 0
+                  ? watchingModifiedFiles
+                  : undefined
               );
-              await this.#angularCompilation.update(watchingModifiedFiles);
 
-              await buildAndAnalyzeWithParallelCompilation(
+              await buildAndAnalyze(
                 this.#angularCompilation,
-                this.#typescriptFileCache,
+                this.#sourceFileCache.typeScriptFileCache,
                 this.#javascriptTransformer
               );
               compiler.hooks.compilation.tap(PLUGIN_NAME, (compilation) => {
@@ -197,7 +200,7 @@ export class AngularRspackPlugin implements RspackPluginInstance {
           });
         }
       }
-      await this.#angularCompilation.close();
+
       await this.#javascriptTransformer.close();
       callback();
     });
@@ -220,7 +223,7 @@ export class AngularRspackPlugin implements RspackPluginInstance {
       (compilation as NgRspackCompilation)[NG_RSPACK_SYMBOL_NAME] = () => ({
         javascriptTransformer: this
           .#javascriptTransformer as unknown as JavaScriptTransformer,
-        typescriptFileCache: this.#typescriptFileCache,
+        typescriptFileCache: this.#sourceFileCache.typeScriptFileCache,
         i18n: this.#i18n,
       });
     });
@@ -272,14 +275,15 @@ export class AngularRspackPlugin implements RspackPluginInstance {
 
   private async setupCompilation(
     root: string,
-    tsConfig: RspackOptionsNormalized['resolve']['tsConfig']
+    tsConfig: RspackOptionsNormalized['resolve']['tsConfig'],
+    modifiedFiles?: Set<string>
   ) {
     const tsconfigPath = tsConfig
       ? typeof tsConfig === 'string'
         ? tsConfig
         : tsConfig.configFile
       : this.#_options.tsConfig;
-    this.#angularCompilation = await setupCompilationWithParallelCompilation(
+    this.#angularCompilation = await setupCompilationWithAngularCompilation(
       {
         source: {
           tsconfigPath: tsconfigPath,
@@ -294,7 +298,9 @@ export class AngularRspackPlugin implements RspackPluginInstance {
         useTsProjectReferences: this.#_options.useTsProjectReferences,
         hasServer: this.#_options.hasServer,
       },
-      this.#angularCompilation
+      this.#sourceFileCache,
+      this.#angularCompilation,
+      modifiedFiles
     );
   }
 }

--- a/packages/angular-rspack/src/lib/plugins/loaders/angular-partial-transform.loader.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/angular-partial-transform.loader.ts
@@ -28,7 +28,11 @@ export default function loader(this: LoaderContext<unknown>, content: string) {
 
     const existingTransform = typescriptFileCache.get(request);
     if (existingTransform) {
-      callback(null, existingTransform);
+      const existingContents =
+        typeof existingTransform === 'string'
+          ? existingTransform
+          : Buffer.from(existingTransform).toString('utf8');
+      callback(null, existingContents);
       return;
     }
 


### PR DESCRIPTION
## Current Behaviour
When `build --watch` or `serve` is run, the Compilation object (ParallelCompilation) is recreated every time.

## Expected Behaviour
During watch, the compilation object should be reused but updated with the latest modified files
