### PR TITLE
fix(angular-rspack): remove options that do not exist in Angular Webpack

### DIFF
--- a/packages/angular-rspack/src/lib/config/create-config.unit.test.ts
+++ b/packages/angular-rspack/src/lib/config/create-config.unit.test.ts
@@ -178,13 +178,13 @@ describe('createConfig', () => {
         createConfig({
           options: {
             ...configBase,
-            clearScreen: true,
+            watch: true,
             devServer: { allowedHosts: ['localhost'] },
           },
         })
       ).resolves.not.toContain([
         expect.objectContaining({
-          clearScreen: true,
+          watch: true,
           devServer: expect.objectContaining({
             allowedHosts: ['localhost'],
           }),
@@ -192,7 +192,7 @@ describe('createConfig', () => {
       ]);
       expect(warnSpy).toHaveBeenCalledWith(
         `The following options are not yet supported:
-  "clearScreen"
+  "watch"
 `
       );
     });

--- a/packages/angular-rspack/src/lib/models/unsupported-options.ts
+++ b/packages/angular-rspack/src/lib/models/unsupported-options.ts
@@ -28,33 +28,21 @@ export interface DevServerUnsupportedOptions {
 }
 
 export interface PluginUnsupportedOptions {
-  security?: {
-    autoCsp?:
-      | boolean
-      | {
-          unsafeEval?: boolean;
-        };
-  };
-  clearScreen?: boolean;
   verbose?: boolean;
   progress?: boolean;
   watch?: boolean;
   budgets?: BudgetEntry[];
   allowedCommonJsDependencies?: string[];
   appShell?: boolean;
-  outputMode?: 'static' | 'server';
 }
 
 export const TOP_LEVEL_OPTIONS_PENDING_SUPPORT = [
-  'security',
-  'clearScreen',
   'verbose',
   'progress',
   'watch',
   'budgets',
   'allowedCommonJsDependencies',
   'appShell',
-  'outputMode',
 ];
 
 export const DEV_SERVER_OPTIONS_PENDING_SUPPORT = [


### PR DESCRIPTION
Remove options that only exist in the Esbuild Application Builder
