### PR TITLE
fix(angular-rspack,angular-rspack-compiler): surface errors from ComponentStylesheetResult ensuring sass andincludePaths are passed

### DIFF
--- a/packages/angular-rspack-compiler/src/compilation/setup-compilation.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-compilation.ts
@@ -1,6 +1,6 @@
 import { RsbuildConfig } from '@rsbuild/core';
 import * as ts from 'typescript';
-import { InlineStyleLanguage, FileReplacement } from '../models';
+import { InlineStyleLanguage, FileReplacement, type Sass } from '../models';
 import { loadCompilerCli } from '../utils';
 import {
   ComponentStylesheetBundler,
@@ -17,6 +17,8 @@ export interface SetupCompilationOptions {
   fileReplacements: Array<FileReplacement>;
   useTsProjectReferences?: boolean;
   hasServer?: boolean;
+  includePaths?: string[];
+  sass?: Sass;
 }
 
 export const DEFAULT_NG_COMPILER_OPTIONS: ts.CompilerOptions = {
@@ -74,6 +76,8 @@ export async function setupCompilation(
           warn: (message) => console.warn(message),
         })
       ),
+      includePaths: options.includePaths,
+      sass: options.sass,
     },
     options.inlineStyleLanguage,
     false

--- a/packages/angular-rspack-compiler/src/compilation/setup-compilation.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-compilation.ts
@@ -2,7 +2,10 @@ import { RsbuildConfig } from '@rsbuild/core';
 import * as ts from 'typescript';
 import { InlineStyleLanguage, FileReplacement } from '../models';
 import { loadCompilerCli } from '../utils';
-import { ComponentStylesheetBundler } from '@angular/build/src/tools/esbuild/angular/component-stylesheets';
+import {
+  ComponentStylesheetBundler,
+  type ComponentStylesheetResult
+} from '@angular/build/src/tools/esbuild/angular/component-stylesheets';
 import { transformSupportedBrowsersToTargets } from '../utils/targets-from-browsers';
 import { getSupportedBrowsers } from '@angular/build/private';
 
@@ -92,7 +95,7 @@ export function styleTransform(
     stylesheetFile?: string
   ) => {
     try {
-      let stylesheetResult;
+      let stylesheetResult: ComponentStylesheetResult;
       if (stylesheetFile) {
         stylesheetResult = await componentStylesheetBundler.bundleFile(
           stylesheetFile
@@ -103,6 +106,14 @@ export function styleTransform(
           containingFile,
           containingFile.endsWith('.html') ? 'css' : undefined
         );
+      }
+      if (stylesheetResult.errors && stylesheetResult.errors.length > 0) {
+        for (const error of stylesheetResult.errors) {
+          console.error(
+            'Failed to compile styles. Continuing execution ignoring failing stylesheet...',
+            error.text
+          );
+        }
       }
       return stylesheetResult.contents;
     } catch (e) {

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
@@ -297,6 +297,8 @@ export class AngularRspackPlugin implements RspackPluginInstance {
         fileReplacements: this.#_options.fileReplacements,
         useTsProjectReferences: this.#_options.useTsProjectReferences,
         hasServer: this.#_options.hasServer,
+        includePaths: this.#_options.stylePreprocessorOptions?.includePaths,
+        sass: this.#_options.stylePreprocessorOptions?.sass,
       },
       this.#sourceFileCache,
       this.#angularCompilation,


### PR DESCRIPTION
If `componentStylesheetBundler.bundleFile()`/`componentStylesheetBundler.bundleInline()` doesn't throw an error but the results still contain errors, the errors will not be reported and the resulting style sheet will be empty.

This makes it really hard to understand, why certain styles are not compiled, as seen here: #76 

---

In addition, this fixes that both `sass` and `includePaths` are not passed to Angular's `ComponentStylesheetBundler`.

Fixes #76