### PR TITLE
test(angular-rsbuild): test compiler helper

### DIFF
--- a/packages/angular-rsbuild/src/lib/config/helpers.integration.test.ts
+++ b/packages/angular-rsbuild/src/lib/config/helpers.integration.test.ts
@@ -1,0 +1,102 @@
+import { deleteOutputDir } from './helpers.ts';
+import { afterAll, beforeEach, expect } from 'vitest';
+import { readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { vol } from 'memfs';
+import { MEMFS_VOLUME } from '@ng-rspack/testing-utils';
+
+describe('deleteOutputDir', () => {
+  const readdirSpy = vi.spyOn(vol, 'readdir');
+  const outputDir = join(MEMFS_VOLUME, 'delete-output-dir');
+
+  beforeEach(() => {
+    readdirSpy.mockClear();
+  });
+
+  afterAll(() => {
+    readdirSpy.mockRestore();
+  });
+
+  it('should remove all folders and files in root', async () => {
+    vol.fromJSON({
+      [join(outputDir, 'sub-dir-1/file-1.txt')]: '',
+      [join(outputDir, 'sub-dir-2/file-2.txt')]: '',
+      [join(outputDir, 'sub-dir-3/file-3.txt')]: '',
+    });
+
+    await expect(readdir(outputDir)).resolves.toStrictEqual([
+      'sub-dir-1',
+      'sub-dir-2',
+      'sub-dir-3',
+    ]);
+    await expect(
+      deleteOutputDir(MEMFS_VOLUME, outputDir)
+    ).resolves.not.toThrow();
+    await expect(readdir(outputDir)).resolves.toStrictEqual([]);
+  });
+
+  it('should remove only folders and files listed in emptyOnly', async () => {
+    vol.fromJSON({
+      [join(outputDir, 'sub-dir-1/file-1.txt')]: '',
+      [join(outputDir, 'sub-dir-2/file-2.txt')]: '',
+      [join(outputDir, 'sub-dir-3/file-3.txt')]: '',
+    });
+
+    await expect(readdir(outputDir)).resolves.toStrictEqual([
+      'sub-dir-1',
+      'sub-dir-2',
+      'sub-dir-3',
+    ]);
+    await expect(
+      deleteOutputDir(MEMFS_VOLUME, outputDir, ['sub-dir-2'])
+    ).resolves.not.toThrow();
+    await expect(readdir(outputDir)).resolves.toStrictEqual(['sub-dir-2']);
+  });
+
+  it('should throw if root is project root', async () => {
+    await expect(deleteOutputDir(MEMFS_VOLUME, MEMFS_VOLUME)).rejects.toThrow(
+      'Output path MUST not be project root directory!'
+    );
+  });
+
+  it('should not throw if output path does not exist', async () => {
+    await expect(
+      deleteOutputDir(MEMFS_VOLUME, 'non-existing-path')
+    ).resolves.not.toThrow();
+  });
+
+  it('should throw if non ENOENT error', async () => {
+    const otherError = new Error('permission denied') as Error & {
+      code: string;
+    };
+    otherError.code = 'EACCES';
+    readdirSpy.mockImplementationOnce(() => {
+      throw otherError;
+    });
+
+    await expect(
+      deleteOutputDir(MEMFS_VOLUME, 'no-permission-path')
+    ).rejects.toThrow(otherError);
+  });
+
+  it('should work when called recursively', async () => {
+    vol.fromJSON({
+      [join(outputDir, 'sub-dir-1/sub-dir-1.1/file-1.txt')]: '',
+      [join(outputDir, 'sub-dir-2/sub-dir-2.1/file-2.txt')]: '',
+      [join(outputDir, 'sub-dir-3/sub-dir-3.1/file-3.txt')]: '',
+    });
+
+    await expect(readdir(outputDir)).resolves.toStrictEqual([
+      'sub-dir-1',
+      'sub-dir-2',
+      'sub-dir-3',
+    ]);
+
+    await expect(
+      deleteOutputDir(MEMFS_VOLUME, outputDir, ['sub-dir-1', 'sub-dir-1.1'])
+    ).resolves.not.toThrow();
+    await expect(readdir(join(outputDir, 'sub-dir-1'))).resolves.toStrictEqual([
+      'sub-dir-1.1',
+    ]);
+  });
+});

--- a/packages/angular-rsbuild/src/lib/config/helpers.ts
+++ b/packages/angular-rsbuild/src/lib/config/helpers.ts
@@ -5,33 +5,34 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-import { OutputHashing, HashFormat } from '../models/plugin-options';
+import { HashFormat, OutputHashing } from '../models/plugin-options';
 import { readdir, rm } from 'node:fs/promises';
-import { join, resolve } from 'node:path';
+import { join, resolve, relative } from 'node:path';
 
 /**
- * Delete an output directory, but error out if it's the root of the project.
+ * Delete an output directory, but error out if it's the root of the project because
+ * that would remove the entire project and could be dangerous.
  */
 export async function deleteOutputDir(
   root: string,
   outputPath: string,
-  emptyOnlyDirectories?: string[]
+  preserveDirs?: string[]
 ): Promise<void> {
   const resolvedOutputPath = resolve(root, outputPath);
   if (resolvedOutputPath === root) {
     throw new Error('Output path MUST not be project root directory!');
   }
 
-  const directoriesToEmpty = emptyOnlyDirectories
+  const directoriesToEmpty = preserveDirs
     ? new Set(
-        emptyOnlyDirectories.map((directory) =>
+        preserveDirs.map((directory) =>
           join(resolvedOutputPath, directory)
         )
       )
     : undefined;
 
   // Avoid removing the actual directory to avoid errors in cases where the output
-  // directory is mounted or symlinked. Instead the contents are removed.
+  // directory is mounted or symlinked. Instead, the contents are removed.
   let entries;
   try {
     entries = await readdir(resolvedOutputPath);
@@ -47,7 +48,9 @@ export async function deleteOutputDir(
 
     // Leave requested directories. This allows symlinks to continue to function.
     if (directoriesToEmpty?.has(fullEntry)) {
-      await deleteOutputDir(resolvedOutputPath, fullEntry);
+      // compute its path relative to `root`, then recurse as in deleteOutputDir resolve is called on root
+      const rel = relative(root, fullEntry);
+      await deleteOutputDir(root, rel, preserveDirs);
       continue;
     }
 

--- a/packages/angular-rsbuild/src/lib/config/helpers.ts
+++ b/packages/angular-rsbuild/src/lib/config/helpers.ts
@@ -25,9 +25,7 @@ export async function deleteOutputDir(
 
   const directoriesToEmpty = preserveDirs
     ? new Set(
-        preserveDirs.map((directory) =>
-          join(resolvedOutputPath, directory)
-        )
+        preserveDirs.map((directory) => join(resolvedOutputPath, directory))
       )
     : undefined;
 

--- a/packages/angular-rsbuild/src/lib/config/helpers.unit.test.ts
+++ b/packages/angular-rsbuild/src/lib/config/helpers.unit.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { getOutputHashFormat } from './helpers';
+
+describe('getOutputHashFormat', () => {
+  const defaultLength = 8;
+  const tpl = (len = defaultLength) => `.[contenthash:${len}]`;
+
+  it('returns no hashes when outputHashing is "none"', () => {
+    expect(getOutputHashFormat('none')).toEqual({
+      chunk: '',
+      extract: '',
+      file: '',
+      script: '',
+    });
+  });
+
+  it('returns file hashes only for "media"', () => {
+    expect(getOutputHashFormat('media')).toEqual({
+      chunk: '',
+      extract: '',
+      file: tpl(),
+      script: '',
+    });
+  });
+
+  it('returns chunk, extract and script hashes for "bundles"', () => {
+    expect(getOutputHashFormat('bundles')).toEqual({
+      chunk: tpl(),
+      extract: tpl(),
+      file: '',
+      script: tpl(),
+    });
+  });
+
+  it('returns hashes everywhere for "all"', () => {
+    expect(getOutputHashFormat('all')).toEqual({
+      chunk: tpl(),
+      extract: tpl(),
+      file: tpl(),
+      script: tpl(),
+    });
+  });
+
+  it('uses the provided length for the template', () => {
+    const len = 16;
+    expect(getOutputHashFormat('all', len)).toEqual({
+      chunk: tpl(len),
+      extract: tpl(len),
+      file: tpl(len),
+      script: tpl(len),
+    });
+    expect(getOutputHashFormat('media', len)).toEqual({
+      chunk: '',
+      extract: '',
+      file: tpl(len),
+      script: '',
+    });
+  });
+
+  it('defaults to "none" when outputHashing is undefined', () => {
+    expect(getOutputHashFormat(undefined)).toEqual({
+      chunk: '',
+      extract: '',
+      file: '',
+      script: '',
+    });
+  });
+
+  it('treats unknown values as "none"', () => {
+    expect(getOutputHashFormat('foobar')).toEqual({
+      chunk: '',
+      extract: '',
+      file: '',
+      script: '',
+    });
+  });
+});

--- a/packages/angular-rsbuild/vitest.integration.config.mts
+++ b/packages/angular-rsbuild/vitest.integration.config.mts
@@ -16,6 +16,7 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['src/**/*.integration.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    setupFiles: ['../../testing/vitest-setup/src/lib/fs-memfs.setup-file.ts'],
     passWithNoTests: true,
     reporters: ['default'],
     coverage: {


### PR DESCRIPTION
This PR includes:
- `unit` tests for compiler helpers
- `integration` tests for compiler helpers
- fix `deleteOutputDir` to work in recursive files