### PR TITLE
fix(angular-rspack): fix ignore glob for .gitkeep

### DIFF
--- a/packages/angular-rspack/src/lib/plugins/ng-rspack.ts
+++ b/packages/angular-rspack/src/lib/plugins/ng-rspack.ts
@@ -86,7 +86,7 @@ export class NgRspackPlugin implements RspackPluginInstance {
             globOptions: {
               dot: true,
               ignore: [
-                '.gitkeep',
+                '**/.gitkeep',
                 '**/.DS_Store',
                 '**/Thumbs.db',
                 ...(asset.ignore ?? []),


### PR DESCRIPTION
Without this fix, `.gitkeep` files in nested folders will still make it into the copied assets.