### PR TITLE
feat(angular-rspack): support pkg scheme importer

### DIFF
--- a/packages/angular-rspack/src/lib/config/config-utils/style-config-utils.ts
+++ b/packages/angular-rspack/src/lib/config/config-utils/style-config-utils.ts
@@ -9,6 +9,7 @@ import {
 import { createRequire } from 'node:module';
 import { basename, dirname, relative, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import { NodePackageImporter } from 'sass';
 import type { FileImporter } from 'sass';
 import type {
   HashFormat,
@@ -328,6 +329,7 @@ function getSassLoaderOptions(
     webpackImporter: false,
     sassOptions: (loaderContext: LoaderContext<unknown>) => ({
       importers: [
+        new NodePackageImporter(),
         getSassResolutionImporter(loaderContext, root, preserveSymlinks),
       ],
       loadPaths: includePaths,


### PR DESCRIPTION
Support [sass pkg URL scheme](https://sass-lang.com/documentation/at-rules/use/#rules-for-a-pkg-importer)

Some UI Libraries export their Sass entry point via ⁠package.json. You can refer to the example below.

```
{
  "exports": {
    ".": {
      "sass": "styles/index.scss",
    },
    "./button.scss": {
      "sass": "styles/button.scss",
    },
    "./accordion.scss": {
      "sass": "styles/accordion.scss",
    }
  }
}
```


