### PR TITLE
fix(angular-rspack): delete build outputPath only once

### DIFF
--- a/packages/angular-rspack/src/lib/config/config-utils/common-config.ts
+++ b/packages/angular-rspack/src/lib/config/config-utils/common-config.ts
@@ -63,7 +63,7 @@ export async function getCommonConfig(
     output: {
       uniqueName: normalizedOptions.projectName ?? 'rspack-angular',
       publicPath: normalizedOptions.deployUrl ?? '',
-      clean: normalizedOptions.deleteOutputPath,
+      clean: false, // already taken care for by AngularRspackPlugin
       crossOriginLoading,
       trustedTypes: { policyName: 'angular#bundler' },
       sourceMapFilename: normalizedOptions.sourceMap.scripts

--- a/packages/angular-rspack/src/lib/config/create-config.ts
+++ b/packages/angular-rspack/src/lib/config/create-config.ts
@@ -51,7 +51,7 @@ export async function _createConfig(
   );
   const hashFormat = getOutputHashFormat(normalizedOptions.outputHashing);
 
-  if (options.deleteOutputPath) {
+  if (normalizedOptions.deleteOutputPath) {
     await deleteOutputDir(
       normalizedOptions.root,
       normalizedOptions.outputPath.base

--- a/packages/angular-rspack/src/lib/config/create-config.unit.test.ts
+++ b/packages/angular-rspack/src/lib/config/create-config.unit.test.ts
@@ -21,6 +21,7 @@ describe('createConfig', () => {
     scripts: [],
     aot: true,
     skipTypeChecking: false,
+    deleteOutputPath: false,
   };
 
   beforeEach(() => {


### PR DESCRIPTION
Fixes https://github.com/nrwl/angular-rspack/issues/116

- delete outputPath based on normalized options
- disable rspack clean option to not delete outputPath twice